### PR TITLE
BUG: Prevent stats on single sample summarize

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -113,15 +113,15 @@ def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
     result.sort_values(inplace=True, ascending=False)
     result.to_csv(os.path.join(output_dir, 'per-sample-fastq-counts.csv'),
                   header=True, index=True)
-    plot_args = {'kde': False}
-    if len(per_sample_fastqs) == 1:
-        plot_args.update({'hist': False})
-    ax = sns.distplot(result, **plot_args)
-    ax.set_xlabel('Number of sequences')
-    ax.set_ylabel('Frequency')
-    fig = ax.get_figure()
-    fig.savefig(os.path.join(output_dir, 'demultiplex-summary.png'))
-    fig.savefig(os.path.join(output_dir, 'demultiplex-summary.pdf'))
+
+    show_plot = len(per_sample_fastqs) > 1
+    if show_plot:
+        ax = sns.distplot(result, kde=False)
+        ax.set_xlabel('Number of sequences')
+        ax.set_ylabel('Frequency')
+        fig = ax.get_figure()
+        fig.savefig(os.path.join(output_dir, 'demultiplex-summary.png'))
+        fig.savefig(os.path.join(output_dir, 'demultiplex-summary.pdf'))
 
     html = result.to_frame().to_html(classes='table table-striped table-hover')
     html = html.replace('border="1"', 'border="0"')
@@ -132,7 +132,8 @@ def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
             'median': result.median(),
             'mean': result.mean(),
             'max': result.max(),
-            'sum': result.sum()
+            'sum': result.sum(),
+            'show_plot': show_plot,
         },
         'result': html
     }

--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -113,7 +113,10 @@ def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
     result.sort_values(inplace=True, ascending=False)
     result.to_csv(os.path.join(output_dir, 'per-sample-fastq-counts.csv'),
                   header=True, index=True)
-    ax = sns.distplot(result, kde=False)
+    plot_args = {'kde': False}
+    if len(per_sample_fastqs) == 1:
+        plot_args.update({'hist': False})
+    ax = sns.distplot(result, **plot_args)
     ax.set_xlabel('Number of sequences')
     ax.set_ylabel('Frequency')
     fig = ax.get_figure()

--- a/q2_demux/assets/index.html
+++ b/q2_demux/assets/index.html
@@ -13,6 +13,8 @@
         </table>
     </div>
 </div>
+
+{% if show_plot %}
 <div class="row">
     <div class="col-lg-12 text-center">
         <a href="demultiplex-summary.pdf">
@@ -21,11 +23,13 @@
         </a>
     </div>
 </div>
+{% endif %}
+
 <div class="row">
     <div class="col-lg-12">
         <h1>Per-sample sequence counts</h1>
         {{ result }}
-        <a href="per-sample-fastq-counts.csv">Download as CSV'</a>
+        <a href="per-sample-fastq-counts.csv">Download as CSV</a>
     </div>
 </div>
 {% endblock %}

--- a/q2_demux/test/test_demux.py
+++ b/q2_demux/test/test_demux.py
@@ -412,3 +412,34 @@ class SummarizeTests(unittest.TestCase):
                 html = fh.read()
                 self.assertIn('<td>Minimum:</td><td>1</td>', html)
                 self.assertIn('<td>Maximum:</td><td>3</td>', html)
+
+    def test_single_sample(self):
+        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY')]
+
+        sequences = [('@s1/1 abc/1', 'GGG', '+', 'YYY')]
+        bsi = BarcodeSequenceFastqIterator(barcodes, sequences)
+
+        barcode_map = pd.Series(['AAAA'], index=['sample1'])
+        barcode_map = qiime.MetadataCategory(barcode_map)
+
+        demux_data = emp(bsi, barcode_map)
+        # test that an index.html file is created and that it has size > 0
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = summarize(output_dir, demux_data)
+            self.assertTrue(result is None)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue(os.path.getsize(index_fp) > 0)
+            csv_fp = os.path.join(output_dir, 'per-sample-fastq-counts.csv')
+            self.assertTrue(os.path.exists(csv_fp))
+            self.assertTrue(os.path.getsize(csv_fp) > 0)
+            pdf_fp = os.path.join(output_dir, 'demultiplex-summary.pdf')
+            self.assertTrue(os.path.exists(pdf_fp))
+            self.assertTrue(os.path.getsize(pdf_fp) > 0)
+            png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
+            self.assertTrue(os.path.exists(png_fp))
+            self.assertTrue(os.path.getsize(png_fp) > 0)
+            with open(index_fp, 'r') as fh:
+                html = fh.read()
+                self.assertIn('<td>Minimum:</td><td>1</td>', html)
+                self.assertIn('<td>Maximum:</td><td>1</td>', html)

--- a/q2_demux/test/test_demux.py
+++ b/q2_demux/test/test_demux.py
@@ -434,11 +434,9 @@ class SummarizeTests(unittest.TestCase):
             self.assertTrue(os.path.exists(csv_fp))
             self.assertTrue(os.path.getsize(csv_fp) > 0)
             pdf_fp = os.path.join(output_dir, 'demultiplex-summary.pdf')
-            self.assertTrue(os.path.exists(pdf_fp))
-            self.assertTrue(os.path.getsize(pdf_fp) > 0)
+            self.assertFalse(os.path.exists(pdf_fp))
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
-            self.assertTrue(os.path.exists(png_fp))
-            self.assertTrue(os.path.getsize(png_fp) > 0)
+            self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
                 html = fh.read()
                 self.assertIn('<td>Minimum:</td><td>1</td>', html)


### PR DESCRIPTION
Fixes #20 

The error stems from Seaborn trying to run stats, but these stats don't make sense when `n=1`.

Right now this just generates a blank plot:
![filevarfolderswm5x6rrpkn5xd_lbgszfr90dl40000gntqiime2archive77ubb393d52332bde92c41aca8bdb2ca6e02b1f1dataindexhtml-full](https://cloud.githubusercontent.com/assets/274668/20933421/34c81f28-bb95-11e6-90f9-51f607e17297.png)

I could also see just skipping the plot when there is only a single sample.