### PR TITLE
BUG: Manage open file count

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -18,6 +18,7 @@ import resource
 import skbio
 import pandas as pd
 import seaborn as sns
+import psutil
 
 import qiime2
 from q2_types.per_sample_sequences import (
@@ -52,6 +53,23 @@ def _record_to_fastq_header(record):
         id, description = tokens
 
     return FastqHeader(id=id, description=description)
+
+
+def _maintain_open_fh_count(per_sample_fastqs):
+    # Get the allotted resources, and sample id keys
+    open_fh_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    sample_ids = list(per_sample_fastqs.keys())
+
+    # If the number of open files reaches the allotted resources limit,
+    # close around 15% of the open files. 15% was chosen because if you
+    # only close a single file it will start to have to do it on every loop
+    # and on a 35 file benchmark using a hard coded limit of 10 files,
+    # only closing one file added an increased runtime of 160%
+    while len(psutil.Process().open_files()) >= open_fh_limit:
+        for i in range(round(len(sample_ids) * 0.15)):
+            rand_sample_id = random.choice(sample_ids)
+            if not per_sample_fastqs[rand_sample_id].closed:
+                per_sample_fastqs[rand_sample_id].close()
 
 
 class BarcodeSequenceFastqIterator(collections.Iterator):
@@ -182,8 +200,6 @@ def emp(seqs: BarcodeSequenceFastqIterator,
     manifest_fh.write('# joined reads\n')
 
     per_sample_fastqs = {}
-    open_fh_count = 0
-    open_fh_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
 
     for barcode_record, sequence_record in seqs:
         barcode_read = barcode_record[1]
@@ -209,25 +225,17 @@ def emp(seqs: BarcodeSequenceFastqIterator,
                                                barcode_id=barcode_id,
                                                lane_number=1,
                                                read_number=1)
+            _maintain_open_fh_count(per_sample_fastqs)
             per_sample_fastqs[sample_id] = gzip.open(str(path), mode='a')
-            open_fh_count += 1
             manifest_fh.write('%s,%s,%s\n' % (sample_id, path.name, 'forward'))
 
         if per_sample_fastqs[sample_id].closed:
+            _maintain_open_fh_count(per_sample_fastqs)
             per_sample_fastqs[sample_id] = gzip.open(str(path), mode='a')
-            open_fh_count += 1
 
         fastq_lines = '\n'.join(sequence_record) + '\n'
         fastq_lines = fastq_lines.encode('utf-8')
         per_sample_fastqs[sample_id].write(fastq_lines)
-
-        sample_ids = list(per_sample_fastqs.keys())
-        id_max = len(per_sample_fastqs) - 1
-        while open_fh_count > open_fh_limit:
-            rand_sample_id = sample_ids[random.randint(0, id_max)]
-            if not per_sample_fastqs[rand_sample_id].closed:
-                per_sample_fastqs[rand_sample_id].close()
-                open_fh_count -= 1
 
     if len(per_sample_fastqs) == 0:
         raise ValueError('No sequences were mapped to samples. Check that '

--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -13,6 +13,7 @@ import itertools
 import collections
 import pkg_resources
 import random
+import resource
 
 import skbio
 import pandas as pd
@@ -182,6 +183,7 @@ def emp(seqs: BarcodeSequenceFastqIterator,
 
     per_sample_fastqs = {}
     open_fh_count = 0
+    open_fh_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
 
     for barcode_record, sequence_record in seqs:
         barcode_read = barcode_record[1]
@@ -219,9 +221,9 @@ def emp(seqs: BarcodeSequenceFastqIterator,
         fastq_lines = fastq_lines.encode('utf-8')
         per_sample_fastqs[sample_id].write(fastq_lines)
 
-        while open_fh_count >= 255:
-            sample_ids = list(per_sample_fastqs.keys())
-            id_max = len(per_sample_fastqs) - 1
+        sample_ids = list(per_sample_fastqs.keys())
+        id_max = len(per_sample_fastqs) - 1
+        while open_fh_count > open_fh_limit:
             rand_sample_id = sample_ids[random.randint(0, id_max)]
             if not per_sample_fastqs[rand_sample_id].closed:
                 per_sample_fastqs[rand_sample_id].close()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
                       'q2templates == 2017.2.*', 'numpy', 'pandas',
-                      'scikit-bio', 'seaborn'],
+                      'scikit-bio', 'seaborn', 'psutil'],
     author="Greg Caporaso",
     author_email="gregcaporaso@gmail.com",
     url="https://qiime2.org",


### PR DESCRIPTION
This should theoretically work. It will keep a limited number of file descriptors open, randomly closing files to keep it under the limit. 

Should the file limit be lower to keep a bigger buffer of open files?

I'm not sure if I love this strategy, but it seemed like one of the more straightforward ways without a full refactor of the method logic.

Resolves #19 