### PR TITLE
BUG: un-nest `show_plot` in jinja template context

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -160,10 +160,10 @@ def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
             'median': result.median(),
             'mean': result.mean(),
             'max': result.max(),
-            'sum': result.sum(),
-            'show_plot': show_plot,
+            'sum': result.sum()
         },
-        'result': html
+        'result': html,
+        'show_plot': show_plot
     }
     q2templates.render(index, output_dir, context=context)
 


### PR DESCRIPTION
Resolves a bug introduced in #21, where the `show_plot` was being nested in `result_data` context, but checked as a standalone context item, preventing plot displaying for all summarize output. (plots were being generated correctly in the visualizer, verified by exporting the data, but the jinja conditional would always return `False` preventing plots from being injected into the template.)