### PR TITLE
ENH/BUG: Add emp_paired, rename emp to emp_single

### DIFF
--- a/q2_demux/__init__.py
+++ b/q2_demux/__init__.py
@@ -8,9 +8,9 @@
 
 import pkg_resources
 
-from ._demux import emp, summarize
+from ._demux import emp_single, emp_paired, summarize
 
 
 __version__ = pkg_resources.get_distribution('q2-demux').version
 
-__all__ = ['emp', 'summarize']
+__all__ = ['emp_single', 'emp_paired', 'summarize']

--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -231,7 +231,8 @@ def emp(seqs: BarcodeSequenceFastqIterator,
 
         if per_sample_fastqs[sample_id].closed:
             _maintain_open_fh_count(per_sample_fastqs)
-            per_sample_fastqs[sample_id] = gzip.open(str(path), mode='a')
+            per_sample_fastqs[sample_id] = gzip.open(
+                per_sample_fastqs[sample_id].name, mode='a')
 
         fastq_lines = '\n'.join(sequence_record) + '\n'
         fastq_lines = fastq_lines.encode('utf-8')

--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -11,6 +11,7 @@ import gzip
 import yaml
 import itertools
 import collections
+import collections.abc
 import pkg_resources
 import random
 import resource
@@ -22,8 +23,9 @@ import psutil
 
 import qiime2
 from q2_types.per_sample_sequences import (
-    SingleLanePerSampleSingleEndFastqDirFmt, FastqManifestFormat, YamlFormat,
-    FastqGzFormat)
+    SingleLanePerSampleSingleEndFastqDirFmt,
+    SingleLanePerSamplePairedEndFastqDirFmt,
+    FastqManifestFormat, YamlFormat, FastqGzFormat)
 import q2templates
 
 
@@ -40,8 +42,15 @@ def _read_fastq_seqs(filepath):
                qual.strip())
 
 
-def _trim_trailing_slash(header):
-    return header.rsplit('/', 1)[0]
+def _trim_id(id):
+    return id.rsplit('/', 1)[0]
+
+
+def _trim_description(desc):
+    # The first number of ':' seperated description is the read number
+    if ':' in desc:
+        desc = desc.split(':', 1)[1]
+    return desc.rsplit('/', 1)[0]
 
 
 def _record_to_fastq_header(record):
@@ -55,24 +64,42 @@ def _record_to_fastq_header(record):
     return FastqHeader(id=id, description=description)
 
 
-def _maintain_open_fh_count(per_sample_fastqs):
-    # Get the allotted resources, and sample id keys
-    open_fh_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-    sample_ids = list(per_sample_fastqs.keys())
+# This is global so that it can be tested without changing the actual ulimits
+OPEN_FH_LIMIT, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+
+
+def _maintain_open_fh_count(per_sample_fastqs, paired=False):
+    files_to_open = 1 if not paired else 2
+    if len(psutil.Process().open_files()) + files_to_open < OPEN_FH_LIMIT:
+        return
+
+    # currently open per-sample files
+    if not paired:
+        open_fhs = [fh for fh in per_sample_fastqs.values()
+                    if not fh.closed]
+    else:
+        open_fhs = [fh for fh in per_sample_fastqs.values()
+                    if not fh[0].closed]
 
     # If the number of open files reaches the allotted resources limit,
     # close around 15% of the open files. 15% was chosen because if you
     # only close a single file it will start to have to do it on every loop
     # and on a 35 file benchmark using a hard coded limit of 10 files,
     # only closing one file added an increased runtime of 160%
-    while len(psutil.Process().open_files()) >= open_fh_limit:
-        for i in range(round(len(sample_ids) * 0.15)):
-            rand_sample_id = random.choice(sample_ids)
-            if not per_sample_fastqs[rand_sample_id].closed:
-                per_sample_fastqs[rand_sample_id].close()
+    n_to_close = round(0.15 * len(open_fhs))
+    if paired:
+        n_to_close //= 2
+    n_to_close = min(len(open_fhs), max(n_to_close, 1))
+    for rand_fh in random.sample(open_fhs, n_to_close):
+        if paired:
+            fwd, rev = rand_fh
+            fwd.close()
+            rev.close()
+        else:
+            rand_fh.close()
 
 
-class BarcodeSequenceFastqIterator(collections.Iterator):
+class BarcodeSequenceFastqIterator(collections.abc.Iterable):
     def __init__(self, barcode_generator, sequence_generator):
         self.barcode_generator = barcode_generator
         self.sequence_generator = sequence_generator
@@ -92,12 +119,12 @@ class BarcodeSequenceFastqIterator(collections.Iterator):
             sequence_header = _record_to_fastq_header(sequence_record)
 
             # confirm that the id fields are equal
-            if _trim_trailing_slash(barcode_header.id) != \
-               _trim_trailing_slash(sequence_header.id):
+            if _trim_id(barcode_header.id) != \
+               _trim_id(sequence_header.id):
                 raise ValueError(
                     'Mismatched sequence ids: %s and %s' %
-                    (_trim_trailing_slash(barcode_header.id),
-                     _trim_trailing_slash(sequence_header.id)))
+                    (_trim_id(barcode_header.id),
+                     _trim_id(sequence_header.id)))
 
             # if a description field is present, confirm that they're equal
             if barcode_header.description is None and \
@@ -111,17 +138,74 @@ class BarcodeSequenceFastqIterator(collections.Iterator):
                 raise ValueError(
                     'Sequence header lines do not contain description fields '
                     'but barcode header lines do.')
-            elif _trim_trailing_slash(barcode_header.description) != \
-                    _trim_trailing_slash(sequence_header.description):
+            elif _trim_description(barcode_header.description) != \
+                    _trim_description(sequence_header.description):
                 raise ValueError(
                     'Mismatched sequence descriptions: %s and %s' %
-                    (_trim_trailing_slash(barcode_header.description),
-                     _trim_trailing_slash(sequence_header.description)))
+                    (_trim_description(barcode_header.description),
+                     _trim_description(sequence_header.description)))
 
             yield barcode_record, sequence_record
 
-    def __next__(self):
-        return next(self.barcode_generator), next(self.sequence_generator)
+
+class BarcodePairedSequenceFastqIterator(collections.abc.Iterable):
+    def __init__(self, barcode_generator, forward_generator,
+                 reverse_generator):
+        self.barcode_generator = barcode_generator
+        self.forward_generator = forward_generator
+        self.reverse_generator = reverse_generator
+
+    def __iter__(self):
+        # Adapted from q2-types
+        for barcode_record, forward_record, reverse_record \
+                in itertools.zip_longest(self.barcode_generator,
+                                         self.forward_generator,
+                                         self.reverse_generator):
+            if barcode_record is None:
+                raise ValueError('More sequences were provided than barcodes.')
+            if forward_record is None or reverse_record is None:
+                raise ValueError('More barcodes were provided than sequences.')
+            # The id or description fields may end with "/read-number", which
+            # will differ between the sequence and barcode reads. Confirm that
+            # they are identical up until the last /
+            barcode_header = _record_to_fastq_header(barcode_record)
+            forward_header = _record_to_fastq_header(forward_record)
+            reverse_header = _record_to_fastq_header(reverse_record)
+
+            # confirm that the id fields are equal
+            if not (_trim_id(barcode_header.id) ==
+                    _trim_id(forward_header.id) ==
+                    _trim_id(reverse_header.id)):
+                raise ValueError(
+                    'Mismatched sequence ids: %s, %s, and %s' %
+                    (_trim_id(barcode_header.id),
+                     _trim_id(forward_header.id),
+                     _trim_id(reverse_header.id)))
+
+            # if a description field is present, confirm that they're equal
+            if barcode_header.description is None and \
+               forward_header.description is None and \
+               reverse_header.description is None:
+                pass
+            elif barcode_header.description is None:
+                raise ValueError(
+                    'Barcode header lines do not contain description fields '
+                    'but sequence header lines do.')
+            elif (forward_header.description is None or
+                  reverse_header.description is None):
+                raise ValueError(
+                    'Sequence header lines do not contain description fields '
+                    'but barcode header lines do.')
+            elif not (_trim_description(barcode_header.description) ==
+                      _trim_description(forward_header.description) ==
+                      _trim_description(reverse_header.description)):
+                raise ValueError(
+                    'Mismatched sequence descriptions: %s, %s, and %s' %
+                    (_trim_description(barcode_header.description),
+                     _trim_description(forward_header.description),
+                     _trim_description(reverse_header.description)))
+
+            yield barcode_record, forward_record, reverse_record
 
 
 def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
@@ -168,11 +252,7 @@ def summarize(output_dir: str, data: SingleLanePerSampleSingleEndFastqDirFmt) \
     q2templates.render(index, output_dir, context=context)
 
 
-def emp(seqs: BarcodeSequenceFastqIterator,
-        barcodes: qiime2.MetadataCategory,
-        rev_comp_barcodes: bool=False,
-        rev_comp_mapping_barcodes: bool=False) \
-        -> SingleLanePerSampleSingleEndFastqDirFmt:
+def _make_barcode_map(barcodes, rev_comp_mapping_barcodes):
     barcode_map = {}
     barcode_len = None
     for sample_id, barcode in barcodes.to_series().iteritems():
@@ -190,7 +270,24 @@ def emp(seqs: BarcodeSequenceFastqIterator,
                              % (barcode, sample_id, barcode_map[barcode]))
         barcode_map[barcode] = sample_id
 
+    return barcode_map, barcode_len
+
+
+def _write_metadata_yaml(dir_fmt):
+    metadata = YamlFormat()
+    metadata.path.write_text(yaml.dump({'phred-offset': 33}))
+    dir_fmt.metadata.write_data(metadata, YamlFormat)
+
+
+def emp_single(seqs: BarcodeSequenceFastqIterator,
+               barcodes: qiime2.MetadataCategory,
+               rev_comp_barcodes: bool=False,
+               rev_comp_mapping_barcodes: bool=False
+               ) -> SingleLanePerSampleSingleEndFastqDirFmt:
+
     result = SingleLanePerSampleSingleEndFastqDirFmt()
+    barcode_map, barcode_len = _make_barcode_map(
+        barcodes, rev_comp_mapping_barcodes)
 
     manifest = FastqManifestFormat()
     manifest_fh = manifest.open()
@@ -250,8 +347,85 @@ def emp(seqs: BarcodeSequenceFastqIterator,
     manifest_fh.close()
     result.manifest.write_data(manifest, FastqManifestFormat)
 
-    metadata = YamlFormat()
-    metadata.path.write_text(yaml.dump({'phred-offset': 33}))
-    result.metadata.write_data(metadata, YamlFormat)
+    _write_metadata_yaml(result)
+
+    return result
+
+
+def emp_paired(seqs: BarcodePairedSequenceFastqIterator,
+               barcodes: qiime2.MetadataCategory,
+               rev_comp_barcodes: bool=False,
+               rev_comp_mapping_barcodes: bool=False
+               ) -> SingleLanePerSamplePairedEndFastqDirFmt:
+
+    result = SingleLanePerSamplePairedEndFastqDirFmt()
+    barcode_map, barcode_len = _make_barcode_map(
+        barcodes, rev_comp_mapping_barcodes)
+
+    manifest = FastqManifestFormat()
+    manifest_fh = manifest.open()
+    manifest_fh.write('sample-id,filename,direction\n')
+
+    per_sample_fastqs = {}
+    for barcode_record, forward_record, reverse_record in seqs:
+        barcode_read = barcode_record[1]
+        if rev_comp_barcodes:
+            barcode_read = str(skbio.DNA(barcode_read).reverse_complement())
+        barcode_read = barcode_read[:barcode_len]
+
+        try:
+            sample_id = barcode_map[barcode_read]
+        except KeyError:
+            # TODO: this should ultimately be logged, but we don't currently
+            # have support for that.
+            continue
+
+        if sample_id not in per_sample_fastqs:
+            barcode_id = len(per_sample_fastqs) + 1
+            fwd_path = result.sequences.path_maker(sample_id=sample_id,
+                                                   barcode_id=barcode_id,
+                                                   lane_number=1,
+                                                   read_number=1)
+            rev_path = result.sequences.path_maker(sample_id=sample_id,
+                                                   barcode_id=barcode_id,
+                                                   lane_number=1,
+                                                   read_number=2)
+
+            _maintain_open_fh_count(per_sample_fastqs, paired=True)
+            per_sample_fastqs[sample_id] = (
+                gzip.open(str(fwd_path), mode='a'),
+                gzip.open(str(rev_path), mode='a')
+            )
+            manifest_fh.write('%s,%s,%s\n' % (sample_id, fwd_path.name,
+                                              'forward'))
+            manifest_fh.write('%s,%s,%s\n' % (sample_id, rev_path.name,
+                                              'reverse'))
+
+        if per_sample_fastqs[sample_id][0].closed:
+            _maintain_open_fh_count(per_sample_fastqs, paired=True)
+            fwd, rev = per_sample_fastqs[sample_id]
+            per_sample_fastqs[sample_id] = (
+                gzip.open(fwd.name, mode='a'),
+                gzip.open(rev.name, mode='a')
+            )
+
+        fwd, rev = per_sample_fastqs[sample_id]
+        fwd.write(('\n'.join(forward_record) + '\n').encode('utf-8'))
+        rev.write(('\n'.join(reverse_record) + '\n').encode('utf-8'))
+
+    if len(per_sample_fastqs) == 0:
+        raise ValueError('No sequences were mapped to samples. Check that '
+                         'your barcodes are in the correct orientation (see '
+                         'rev_comp_barcodes and/or rev_comp_mapping_barcodes '
+                         'options).')
+
+    for fwd, rev in per_sample_fastqs.values():
+        fwd.close()
+        rev.close()
+
+    manifest_fh.close()
+    result.manifest.write_data(manifest, FastqManifestFormat)
+
+    _write_metadata_yaml(result)
 
     return result

--- a/q2_demux/_format.py
+++ b/q2_demux/_format.py
@@ -18,12 +18,34 @@ class EMPMultiplexedDirFmt(model.DirectoryFormat):
         r'barcodes.fastq.gz', format=FastqGzFormat)
 
 
+class PairedEMPMultiplexedDirFmt(model.DirectoryFormat):
+    forward = model.File(
+        r'forward.fastq.gz', format=FastqGzFormat)
+
+    reverse = model.File(
+        r'reverse.fastq.gz', format=FastqGzFormat)
+
+    barcodes = model.File(
+        r'barcodes.fastq.gz', format=FastqGzFormat)
+
+
 class EMPMultiplexedSingleEndDirFmt(model.DirectoryFormat):
     # TODO: generalize this with a regex when we have validation in place for
     # model.FileCollections. The file names are currently designed more
     # specificially for handling MiSeq data.
     sequences = model.File(
         r'Undetermined_S0_L001_R1_001.fastq.gz', format=FastqGzFormat)
+
+    barcodes = model.File(
+        r'Undetermined_S0_L001_I1_001.fastq.gz', format=FastqGzFormat)
+
+
+class EMPMultiplexedPairedEndDirFmt(model.DirectoryFormat):
+    forward = model.File(
+        r'Undetermined_S0_L001_R1_001.fastq.gz', format=FastqGzFormat)
+
+    reverse = model.File(
+        r'Undetermined_S0_L001_R2_001.fastq.gz', format=FastqGzFormat)
 
     barcodes = model.File(
         r'Undetermined_S0_L001_I1_001.fastq.gz', format=FastqGzFormat)

--- a/q2_demux/_format.py
+++ b/q2_demux/_format.py
@@ -10,6 +10,7 @@ from q2_types.per_sample_sequences import FastqGzFormat
 import qiime2.plugin.model as model
 
 
+# TODO: deprecate this and alias it
 class EMPMultiplexedDirFmt(model.DirectoryFormat):
     sequences = model.File(
         r'sequences.fastq.gz', format=FastqGzFormat)
@@ -18,7 +19,12 @@ class EMPMultiplexedDirFmt(model.DirectoryFormat):
         r'barcodes.fastq.gz', format=FastqGzFormat)
 
 
-class PairedEMPMultiplexedDirFmt(model.DirectoryFormat):
+# The new cannonical name for EMPMultiplexedDirFmt
+class EMPSingleEndDirFmt(EMPMultiplexedDirFmt):
+    pass  # contents inherited
+
+
+class EMPPairedEndDirFmt(model.DirectoryFormat):
     forward = model.File(
         r'forward.fastq.gz', format=FastqGzFormat)
 
@@ -29,7 +35,9 @@ class PairedEMPMultiplexedDirFmt(model.DirectoryFormat):
         r'barcodes.fastq.gz', format=FastqGzFormat)
 
 
-class EMPMultiplexedSingleEndDirFmt(model.DirectoryFormat):
+# Originally called EMPMultiplexedSingleEndDirFmt, rename was possible as no
+# artifacts where created with this view, it is just for import.
+class EMPSingleEndCasavaDirFmt(model.DirectoryFormat):
     # TODO: generalize this with a regex when we have validation in place for
     # model.FileCollections. The file names are currently designed more
     # specificially for handling MiSeq data.
@@ -40,7 +48,7 @@ class EMPMultiplexedSingleEndDirFmt(model.DirectoryFormat):
         r'Undetermined_S0_L001_I1_001.fastq.gz', format=FastqGzFormat)
 
 
-class EMPMultiplexedPairedEndDirFmt(model.DirectoryFormat):
+class EMPPairedEndCasavaDirFmt(model.DirectoryFormat):
     forward = model.File(
         r'Undetermined_S0_L001_R1_001.fastq.gz', format=FastqGzFormat)
 

--- a/q2_demux/_transformer.py
+++ b/q2_demux/_transformer.py
@@ -13,13 +13,13 @@ from q2_types.per_sample_sequences import FastqGzFormat
 from .plugin_setup import plugin
 from ._demux import (BarcodeSequenceFastqIterator,
                      BarcodePairedSequenceFastqIterator, _read_fastq_seqs)
-from ._format import (
-    EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
-    PairedEMPMultiplexedDirFmt, EMPMultiplexedPairedEndDirFmt)
+from ._format import (EMPMultiplexedDirFmt,
+                      EMPSingleEndDirFmt, EMPSingleEndCasavaDirFmt,
+                      EMPPairedEndDirFmt, EMPPairedEndCasavaDirFmt)
 
 
 @plugin.register_transformer
-def _1(dirfmt: EMPMultiplexedDirFmt) -> BarcodeSequenceFastqIterator:
+def _1(dirfmt: EMPSingleEndDirFmt) -> BarcodeSequenceFastqIterator:
     barcode_generator = _read_fastq_seqs(
         str(dirfmt.barcodes.view(FastqGzFormat)))
     sequence_generator = _read_fastq_seqs(
@@ -32,8 +32,16 @@ def _1(dirfmt: EMPMultiplexedDirFmt) -> BarcodeSequenceFastqIterator:
     return result
 
 
+# TODO: remove this when names are aliased
 @plugin.register_transformer
-def _2(dirfmt: EMPMultiplexedSingleEndDirFmt) -> EMPMultiplexedDirFmt:
+def _1_legacy(dirfmt: EMPMultiplexedDirFmt) -> BarcodeSequenceFastqIterator:
+    return _1(dirfmt)
+
+
+# NOTE: a legacy transformer isn't needed for EMPMultiplexedSingleEndDirFmt
+# as no artifacts exist in this form, it is used for import only.
+@plugin.register_transformer
+def _2(dirfmt: EMPSingleEndCasavaDirFmt) -> EMPSingleEndDirFmt:
     # TODO: revisit this API to simpify defining transformers
     result = EMPMultiplexedDirFmt().path
 
@@ -46,7 +54,7 @@ def _2(dirfmt: EMPMultiplexedSingleEndDirFmt) -> EMPMultiplexedDirFmt:
 
 
 @plugin.register_transformer
-def _3(dirfmt: EMPMultiplexedPairedEndDirFmt) -> PairedEMPMultiplexedDirFmt:
+def _3(dirfmt: EMPPairedEndCasavaDirFmt) -> EMPPairedEndDirFmt:
     result = EMPMultiplexedDirFmt()
     root = result.path
 
@@ -61,9 +69,7 @@ def _3(dirfmt: EMPMultiplexedPairedEndDirFmt) -> PairedEMPMultiplexedDirFmt:
 
 
 @plugin.register_transformer
-def _5(dirfmt: PairedEMPMultiplexedDirFmt) \
-        -> BarcodePairedSequenceFastqIterator:
-
+def _4(dirfmt: EMPPairedEndDirFmt) -> BarcodePairedSequenceFastqIterator:
     barcode_generator = _read_fastq_seqs(
         str(dirfmt.barcodes.view(FastqGzFormat)))
     forward_generator = _read_fastq_seqs(

--- a/q2_demux/_transformer.py
+++ b/q2_demux/_transformer.py
@@ -11,8 +11,11 @@ import shutil
 from q2_types.per_sample_sequences import FastqGzFormat
 
 from .plugin_setup import plugin
-from ._demux import BarcodeSequenceFastqIterator, _read_fastq_seqs
-from ._format import EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt
+from ._demux import (BarcodeSequenceFastqIterator,
+                     BarcodePairedSequenceFastqIterator, _read_fastq_seqs)
+from ._format import (
+    EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
+    PairedEMPMultiplexedDirFmt, EMPMultiplexedPairedEndDirFmt)
 
 
 @plugin.register_transformer
@@ -39,4 +42,38 @@ def _2(dirfmt: EMPMultiplexedSingleEndDirFmt) -> EMPMultiplexedDirFmt:
     shutil.copyfile(str(dirfmt.sequences.view(FastqGzFormat)), sequences_fp)
     shutil.copyfile(str(dirfmt.barcodes.view(FastqGzFormat)), barcodes_fp)
 
+    return result
+
+
+@plugin.register_transformer
+def _3(dirfmt: EMPMultiplexedPairedEndDirFmt) -> PairedEMPMultiplexedDirFmt:
+    result = EMPMultiplexedDirFmt()
+    root = result.path
+
+    forward_fp = str(root / 'forward.fastq.gz')
+    reverse_fp = str(root / 'reverse.fastq.gz')
+    barcodes_fp = str(root / 'barcodes.fastq.gz')
+    shutil.copyfile(str(dirfmt.forward.view(FastqGzFormat)), forward_fp)
+    shutil.copyfile(str(dirfmt.reverse.view(FastqGzFormat)), reverse_fp)
+    shutil.copyfile(str(dirfmt.barcodes.view(FastqGzFormat)), barcodes_fp)
+
+    return result
+
+
+@plugin.register_transformer
+def _5(dirfmt: PairedEMPMultiplexedDirFmt) \
+        -> BarcodePairedSequenceFastqIterator:
+
+    barcode_generator = _read_fastq_seqs(
+        str(dirfmt.barcodes.view(FastqGzFormat)))
+    forward_generator = _read_fastq_seqs(
+        str(dirfmt.forward.view(FastqGzFormat)))
+    reverse_generator = _read_fastq_seqs(
+        str(dirfmt.reverse.view(FastqGzFormat)))
+    result = BarcodePairedSequenceFastqIterator(barcode_generator,
+                                                forward_generator,
+                                                reverse_generator)
+    # ensure that dirfmt stays in scope as long as result does so these
+    # generators will work.
+    result.__dirfmt = dirfmt
     return result

--- a/q2_demux/_type.py
+++ b/q2_demux/_type.py
@@ -8,4 +8,9 @@
 
 from qiime2.plugin import SemanticType
 
+# TODO: migrate these to q2-types someday
 RawSequences = SemanticType('RawSequences')
+
+EMPSequences = SemanticType('EMPSequences')
+
+EMPPairedSequences = SemanticType('EMPPairedSequences')

--- a/q2_demux/_type.py
+++ b/q2_demux/_type.py
@@ -11,6 +11,6 @@ from qiime2.plugin import SemanticType
 # TODO: migrate these to q2-types someday
 RawSequences = SemanticType('RawSequences')
 
-EMPSequences = SemanticType('EMPSequences')
+EMPSingleEndSequences = SemanticType('EMPSingleEndSequences')
 
-EMPPairedSequences = SemanticType('EMPPairedSequences')
+EMPPairedEndSequences = SemanticType('EMPPairedEndSequences')

--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -15,10 +15,10 @@ from q2_types.per_sample_sequences import (
     SequencesWithQuality, PairedEndSequencesWithQuality)
 
 import q2_demux
-from ._type import RawSequences, EMPSequences, EMPPairedSequences
-from ._format import (
-    EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
-    PairedEMPMultiplexedDirFmt, EMPMultiplexedPairedEndDirFmt)
+from ._type import RawSequences, EMPSingleEndSequences, EMPPairedEndSequences
+from ._format import (EMPMultiplexedDirFmt,
+                      EMPSingleEndDirFmt, EMPSingleEndCasavaDirFmt,
+                      EMPPairedEndDirFmt, EMPPairedEndCasavaDirFmt)
 
 
 plugin = qiime2.plugin.Plugin(
@@ -30,33 +30,35 @@ plugin = qiime2.plugin.Plugin(
     citation_text=None
 )
 
-plugin.register_semantic_types(RawSequences, EMPSequences, EMPPairedSequences)
+plugin.register_semantic_types(
+    RawSequences, EMPSingleEndSequences, EMPPairedEndSequences)
 
-plugin.register_formats(EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
-                        PairedEMPMultiplexedDirFmt,
-                        EMPMultiplexedPairedEndDirFmt)
+plugin.register_formats(EMPMultiplexedDirFmt,
+                        EMPSingleEndDirFmt, EMPSingleEndCasavaDirFmt,
+                        EMPPairedEndDirFmt, EMPPairedEndCasavaDirFmt)
 
+# TODO: remove when aliasing exists
 plugin.register_semantic_type_to_format(
     RawSequences,
-    artifact_format=EMPMultiplexedDirFmt
+    artifact_format=EMPSingleEndDirFmt
 )
 
 plugin.register_semantic_type_to_format(
-    EMPSequences,
-    artifact_format=EMPMultiplexedDirFmt
+    EMPSingleEndSequences,
+    artifact_format=EMPSingleEndDirFmt
 )
 
 
 plugin.register_semantic_type_to_format(
-    EMPPairedSequences,
-    artifact_format=PairedEMPMultiplexedDirFmt
+    EMPPairedEndSequences,
+    artifact_format=EMPPairedEndDirFmt
 )
 
 
 plugin.methods.register_function(
     function=q2_demux.emp_single,
     # TODO: remove RawSequences by creating an alias to EMPSequences
-    inputs={'seqs': RawSequences | EMPSequences},
+    inputs={'seqs': RawSequences | EMPSingleEndSequences},
     parameters={'barcodes': qiime2.plugin.MetadataCategory,
                 'rev_comp_barcodes': qiime2.plugin.Bool,
                 'rev_comp_mapping_barcodes': qiime2.plugin.Bool},
@@ -71,18 +73,19 @@ plugin.methods.register_function(
 
 plugin.methods.register_function(
     function=q2_demux.emp_paired,
-    inputs={'seqs': EMPPairedSequences},
+    inputs={'seqs': EMPPairedEndSequences},
     parameters={'barcodes': qiime2.plugin.MetadataCategory,
                 'rev_comp_barcodes': qiime2.plugin.Bool,
                 'rev_comp_mapping_barcodes': qiime2.plugin.Bool},
     outputs=[
         ('per_sample_sequences', SampleData[PairedEndSequencesWithQuality])
     ],
-    name='Demultiplex paired sequence data generated with the EMP protocol.',
-    description=('Demultiplex paired sequence data (i.e., map barcode reads '
-                 'to sample ids) for data generated with the Earth Microbiome '
-                 'Project (EMP) amplicon sequencing protocol. Details about '
-                 'this protocol can be found at '
+    name=('Demultiplex paired-end sequence data generated with the EMP '
+          'protocol.'),
+    description=('Demultiplex paired-end sequence data (i.e., map barcode '
+                 'reads to sample ids) for data generated with the Earth '
+                 'Microbiome Project (EMP) amplicon sequencing protocol. '
+                 'Details about this protocol can be found at '
                  'http://www.earthmicrobiome.org/emp-standard-protocols/')
 )
 

--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -11,11 +11,14 @@ import importlib
 import qiime2
 import qiime2.plugin
 from q2_types.sample_data import SampleData
-from q2_types.per_sample_sequences import SequencesWithQuality
+from q2_types.per_sample_sequences import (
+    SequencesWithQuality, PairedEndSequencesWithQuality)
 
 import q2_demux
-from ._type import RawSequences
-from ._format import EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt
+from ._type import RawSequences, EMPSequences, EMPPairedSequences
+from ._format import (
+    EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
+    PairedEMPMultiplexedDirFmt, EMPMultiplexedPairedEndDirFmt)
 
 
 plugin = qiime2.plugin.Plugin(
@@ -27,18 +30,33 @@ plugin = qiime2.plugin.Plugin(
     citation_text=None
 )
 
-plugin.register_semantic_types(RawSequences)
+plugin.register_semantic_types(RawSequences, EMPSequences, EMPPairedSequences)
 
-plugin.register_formats(EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt)
+plugin.register_formats(EMPMultiplexedDirFmt, EMPMultiplexedSingleEndDirFmt,
+                        PairedEMPMultiplexedDirFmt,
+                        EMPMultiplexedPairedEndDirFmt)
 
 plugin.register_semantic_type_to_format(
     RawSequences,
     artifact_format=EMPMultiplexedDirFmt
 )
 
+plugin.register_semantic_type_to_format(
+    EMPSequences,
+    artifact_format=EMPMultiplexedDirFmt
+)
+
+
+plugin.register_semantic_type_to_format(
+    EMPPairedSequences,
+    artifact_format=PairedEMPMultiplexedDirFmt
+)
+
+
 plugin.methods.register_function(
-    function=q2_demux.emp,
-    inputs={'seqs': RawSequences},
+    function=q2_demux.emp_single,
+    # TODO: remove RawSequences by creating an alias to EMPSequences
+    inputs={'seqs': RawSequences | EMPSequences},
     parameters={'barcodes': qiime2.plugin.MetadataCategory,
                 'rev_comp_barcodes': qiime2.plugin.Bool,
                 'rev_comp_mapping_barcodes': qiime2.plugin.Bool},
@@ -46,6 +64,23 @@ plugin.methods.register_function(
     name='Demultiplex sequence data generated with the EMP protocol.',
     description=('Demultiplex sequence data (i.e., map barcode reads to '
                  'sample ids) for data generated with the Earth Microbiome '
+                 'Project (EMP) amplicon sequencing protocol. Details about '
+                 'this protocol can be found at '
+                 'http://www.earthmicrobiome.org/emp-standard-protocols/')
+)
+
+plugin.methods.register_function(
+    function=q2_demux.emp_paired,
+    inputs={'seqs': EMPPairedSequences},
+    parameters={'barcodes': qiime2.plugin.MetadataCategory,
+                'rev_comp_barcodes': qiime2.plugin.Bool,
+                'rev_comp_mapping_barcodes': qiime2.plugin.Bool},
+    outputs=[
+        ('per_sample_sequences', SampleData[PairedEndSequencesWithQuality])
+    ],
+    name='Demultiplex paired sequence data generated with the EMP protocol.',
+    description=('Demultiplex paired sequence data (i.e., map barcode reads '
+                 'to sample ids) for data generated with the Earth Microbiome '
                  'Project (EMP) amplicon sequencing protocol. Details about '
                  'this protocol can be found at '
                  'http://www.earthmicrobiome.org/emp-standard-protocols/')

--- a/q2_demux/test/test_demux.py
+++ b/q2_demux/test/test_demux.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import unittest
+import unittest.mock as mock
 import os.path
 import tempfile
 
@@ -16,8 +17,9 @@ import qiime2
 import numpy as np
 import numpy.testing as npt
 
-from q2_demux._demux import BarcodeSequenceFastqIterator
-from q2_demux import emp, summarize
+from q2_demux._demux import (BarcodeSequenceFastqIterator,
+                             BarcodePairedSequenceFastqIterator)
+from q2_demux import emp_single, emp_paired, summarize
 from q2_types.per_sample_sequences import (
     FastqGzFormat, FastqManifestFormat, YamlFormat)
 
@@ -162,23 +164,7 @@ class BarcodeSequenceFastqIteratorTests(unittest.TestCase):
             list(bsi)
 
 
-class EmpTests(unittest.TestCase):
-
-    def setUp(self):
-        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
-                    ('@s2/2 abc/2', 'AAAA', '+', 'PPPP'),
-                    ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
-                    ('@s4/2 abc/2', 'AACC', '+', 'PPPP')]
-
-        self.sequences = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
-                          ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
-                          ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
-                          ('@s4/1 abc/1', 'TTT', '+', 'PPP')]
-        self.bsi = BarcodeSequenceFastqIterator(barcodes, self.sequences)
-
-        barcode_map = pd.Series(['AAAA', 'AACC'], index=['sample1', 'sample2'])
-        self.barcode_map = qiime2.MetadataCategory(barcode_map)
-
+class EmpTestingUtils:
     def _decode_qual_to_phred(self, qual_str):
         # this function is adapted from scikit-bio
         qual = np.fromstring(qual_str, dtype=np.uint8) - 33
@@ -197,37 +183,82 @@ class EmpTests(unittest.TestCase):
         act_manifest = [l for l in act_manifest if not l.startswith('#')]
         self.assertEqual(act_manifest, exp_manifest)
 
+    def _validate_sample_fastq(self, fastq, sequences, indices):
+        seqs = skbio.io.read(fastq, format='fastq', phred_offset=33,
+                             compression='gzip', constructor=skbio.DNA)
+        seqs = list(seqs)
+        self.assertEqual(len(seqs), len(indices))
+        for idx, i in enumerate(indices):
+            self._compare_sequence_to_record(seqs[idx], sequences[i])
+
+
+class EmpSingleTests(unittest.TestCase, EmpTestingUtils):
+
+    def setUp(self):
+        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'TTAA', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAA', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'AACC', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'AAAA', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'CGGC', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'GGAA', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'CGGC', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'CGGC', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'GGAA', '+', 'PPPP')]
+
+        self.sequences = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                          ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                          ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                          ('@s4/1 abc/1', 'TTT', '+', 'PPP'),
+                          ('@s5/1 abc/1', 'ATA', '+', 'PPP'),
+                          ('@s6/1 abc/1', 'TAT', '+', 'PPP'),
+                          ('@s7/1 abc/1', 'CGC', '+', 'PPP'),
+                          ('@s8/1 abc/1', 'GCG', '+', 'PPP'),
+                          ('@s9/1 abc/1', 'ACG', '+', 'PPP'),
+                          ('@s10/1 abc/1', 'GCA', '+', 'PPP'),
+                          ('@s11/1 abc/1', 'TGA', '+', 'PPP')]
+        self.bsi = BarcodeSequenceFastqIterator(barcodes, self.sequences)
+
+        barcode_map = pd.Series(['AAAA', 'AACC', 'TTAA', 'GGAA', 'CGGC'],
+                                index=['sample1', 'sample2', 'sample3',
+                                       'sample4', 'sample5'])
+        self.barcode_map = qiime2.MetadataCategory(barcode_map)
+
     def test_valid(self):
-        actual = emp(self.bsi, self.barcode_map)
+        actual = emp_single(self.bsi, self.barcode_map)
         output_fastq = list(actual.sequences.iter_views(FastqGzFormat))
-        # two per-sample files were written
-        self.assertEqual(len(output_fastq), 2)
+        # five per-sample files were written
+        self.assertEqual(len(output_fastq), 5)
 
         # sequences in sample1 are correct
-        sample1_seqs = skbio.io.read(output_fastq[0][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample1_seqs = list(sample1_seqs)
-        self.assertEqual(len(sample1_seqs), 2)
-        self._compare_sequence_to_record(sample1_seqs[0], self.sequences[0])
-        self._compare_sequence_to_record(sample1_seqs[1], self.sequences[1])
+        self._validate_sample_fastq(
+            output_fastq[0][1].open(), self.sequences, [0, 5])
 
         # sequences in sample2 are correct
-        sample2_seqs = skbio.io.read(output_fastq[1][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample2_seqs = list(sample2_seqs)
-        self.assertEqual(len(sample2_seqs), 2)
-        self._compare_sequence_to_record(sample2_seqs[0], self.sequences[2])
-        self._compare_sequence_to_record(sample2_seqs[1], self.sequences[3])
+        self._validate_sample_fastq(
+            output_fastq[1][1].open(), self.sequences, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            output_fastq[2][1].open(), self.sequences, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            output_fastq[3][1].open(), self.sequences, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            output_fastq[4][1].open(), self.sequences, [6, 8, 9])
 
         # manifest is correct
         act_manifest = list(actual.manifest.view(FastqManifestFormat).open())
         exp_manifest = ['sample-id,filename,direction\n',
                         'sample1,sample1_1_L001_R1_001.fastq.gz,forward\n',
-                        'sample2,sample2_2_L001_R1_001.fastq.gz,forward\n']
+                        'sample3,sample3_2_L001_R1_001.fastq.gz,forward\n',
+                        'sample2,sample2_3_L001_R1_001.fastq.gz,forward\n',
+                        'sample5,sample5_4_L001_R1_001.fastq.gz,forward\n',
+                        'sample4,sample4_5_L001_R1_001.fastq.gz,forward\n']
         self._compare_manifests(act_manifest, exp_manifest)
 
         # metadata is correct
@@ -235,57 +266,66 @@ class EmpTests(unittest.TestCase):
         exp_metadata = ["{phred-offset: 33}\n"]
         self.assertEqual(act_metadata, exp_metadata)
 
+    @mock.patch('q2_demux._demux.OPEN_FH_LIMIT', 3)
+    def test_valid_small_open_fh_limit(self):
+        self.test_valid()
+
     def test_variable_length_barcodes(self):
         barcodes = pd.Series(['AAA', 'AACC'], index=['sample1', 'sample2'])
         barcodes = qiime2.MetadataCategory(barcodes)
         with self.assertRaises(ValueError):
-            emp(self.bsi, barcodes)
+            emp_single(self.bsi, barcodes)
 
     def test_duplicate_barcodes(self):
         barcodes = pd.Series(['AACC', 'AACC'], index=['sample1', 'sample2'])
         barcodes = qiime2.MetadataCategory(barcodes)
         with self.assertRaises(ValueError):
-            emp(self.bsi, barcodes)
+            emp_single(self.bsi, barcodes)
 
     def test_no_matched_barcodes(self):
         barcodes = pd.Series(['CCCC', 'GGCC'], index=['sample1', 'sample2'])
         barcodes = qiime2.MetadataCategory(barcodes)
         with self.assertRaises(ValueError):
-            emp(self.bsi, barcodes)
+            emp_single(self.bsi, barcodes)
 
     def test_rev_comp_mapping_barcodes(self):
-        barcodes = pd.Series(['TTTT', 'GGTT'], index=['sample1', 'sample2'])
+        barcodes = pd.Series(['TTTT', 'GGTT', 'TTAA', 'TTCC', 'GCCG'],
+                             index=['sample1', 'sample2', 'sample3', 'sample4',
+                                    'sample5'])
         barcodes = qiime2.MetadataCategory(barcodes)
-        actual = emp(self.bsi, barcodes, rev_comp_mapping_barcodes=True)
+        actual = emp_single(self.bsi, barcodes, rev_comp_mapping_barcodes=True)
         output_fastq = list(actual.sequences.iter_views(FastqGzFormat))
-        # two per-sample files were written
-        self.assertEqual(len(output_fastq), 2)
+        # five per-sample files were written
+        self.assertEqual(len(output_fastq), 5)
 
         # sequences in sample1 are correct
-        sample1_seqs = skbio.io.read(output_fastq[0][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample1_seqs = list(sample1_seqs)
-        self.assertEqual(len(sample1_seqs), 2)
-        self._compare_sequence_to_record(sample1_seqs[0], self.sequences[0])
-        self._compare_sequence_to_record(sample1_seqs[1], self.sequences[1])
+        self._validate_sample_fastq(
+            output_fastq[0][1].open(), self.sequences, [0, 5])
 
         # sequences in sample2 are correct
-        sample2_seqs = skbio.io.read(output_fastq[1][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample2_seqs = list(sample2_seqs)
-        self.assertEqual(len(sample2_seqs), 2)
-        self._compare_sequence_to_record(sample2_seqs[0], self.sequences[2])
-        self._compare_sequence_to_record(sample2_seqs[1], self.sequences[3])
+        self._validate_sample_fastq(
+            output_fastq[1][1].open(), self.sequences, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            output_fastq[2][1].open(), self.sequences, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            output_fastq[3][1].open(), self.sequences, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            output_fastq[4][1].open(), self.sequences, [6, 8, 9])
 
         # manifest is correct
         act_manifest = list(actual.manifest.view(FastqManifestFormat).open())
         exp_manifest = ['sample-id,filename,direction\n',
                         'sample1,sample1_1_L001_R1_001.fastq.gz,forward\n',
-                        'sample2,sample2_2_L001_R1_001.fastq.gz,forward\n']
+                        'sample3,sample3_2_L001_R1_001.fastq.gz,forward\n',
+                        'sample2,sample2_3_L001_R1_001.fastq.gz,forward\n',
+                        'sample5,sample5_4_L001_R1_001.fastq.gz,forward\n',
+                        'sample4,sample4_5_L001_R1_001.fastq.gz,forward\n']
         self._compare_manifests(act_manifest, exp_manifest)
 
         # metadata is correct
@@ -295,40 +335,50 @@ class EmpTests(unittest.TestCase):
 
     def test_rev_comp_barcodes(self):
         barcodes = [('@s1/2 abc/2', 'TTTT', '+', 'YYYY'),
-                    ('@s2/2 abc/2', 'TTTT', '+', 'PPPP'),
+                    ('@s2/2 abc/2', 'TTAA', '+', 'PPPP'),
                     ('@s3/2 abc/2', 'GGTT', '+', 'PPPP'),
-                    ('@s4/2 abc/2', 'GGTT', '+', 'PPPP')]
+                    ('@s4/2 abc/2', 'TTAA', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'GGTT', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'TTTT', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'TTCC', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'TTCC', '+', 'PPPP')]
         bsi = BarcodeSequenceFastqIterator(barcodes, self.sequences)
-        actual = emp(bsi, self.barcode_map, rev_comp_barcodes=True)
+        actual = emp_single(bsi, self.barcode_map, rev_comp_barcodes=True)
         output_fastq = list(actual.sequences.iter_views(FastqGzFormat))
-        # two per-sample files were written
-        self.assertEqual(len(output_fastq), 2)
+        # five per-sample files were written
+        self.assertEqual(len(output_fastq), 5)
 
         # sequences in sample1 are correct
-        sample1_seqs = skbio.io.read(output_fastq[0][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample1_seqs = list(sample1_seqs)
-        self.assertEqual(len(sample1_seqs), 2)
-        self._compare_sequence_to_record(sample1_seqs[0], self.sequences[0])
-        self._compare_sequence_to_record(sample1_seqs[1], self.sequences[1])
+        self._validate_sample_fastq(
+            output_fastq[0][1].open(), self.sequences, [0, 5])
 
         # sequences in sample2 are correct
-        sample2_seqs = skbio.io.read(output_fastq[1][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample2_seqs = list(sample2_seqs)
-        self.assertEqual(len(sample2_seqs), 2)
-        self._compare_sequence_to_record(sample2_seqs[0], self.sequences[2])
-        self._compare_sequence_to_record(sample2_seqs[1], self.sequences[3])
+        self._validate_sample_fastq(
+            output_fastq[1][1].open(), self.sequences, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            output_fastq[2][1].open(), self.sequences, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            output_fastq[3][1].open(), self.sequences, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            output_fastq[4][1].open(), self.sequences, [6, 8, 9])
 
         # manifest is correct
         act_manifest = list(actual.manifest.view(FastqManifestFormat).open())
         exp_manifest = ['sample-id,filename,direction\n',
                         'sample1,sample1_1_L001_R1_001.fastq.gz,forward\n',
-                        'sample2,sample2_2_L001_R1_001.fastq.gz,forward\n']
+                        'sample3,sample3_2_L001_R1_001.fastq.gz,forward\n',
+                        'sample2,sample2_3_L001_R1_001.fastq.gz,forward\n',
+                        'sample5,sample5_4_L001_R1_001.fastq.gz,forward\n',
+                        'sample4,sample4_5_L001_R1_001.fastq.gz,forward\n']
         self._compare_manifests(act_manifest, exp_manifest)
 
         # metadata is correct
@@ -339,47 +389,248 @@ class EmpTests(unittest.TestCase):
     def test_barcode_trimming(self):
         # these barcodes are longer then the ones in the mapping file, so
         # only the first barcode_length bases should be read
-        barcodes = [('@s1/2 abc/2', 'AAAAG', '+', 'YYYYY'),
-                    ('@s2/2 abc/2', 'AAAAG', '+', 'PPPPP'),
-                    ('@s3/2 abc/2', 'AACCG', '+', 'PPPPP'),
-                    ('@s4/2 abc/2', 'AACCG', '+', 'PPPPP')]
+        barcodes = [('@s1/2 abc/2', 'AAAAG', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACCG', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'AACCG', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'AAAAG', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'GGAAG', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'GGAAG', '+', 'PPPP')]
         bsi = BarcodeSequenceFastqIterator(barcodes, self.sequences)
-        actual = emp(bsi, self.barcode_map)
+        actual = emp_single(bsi, self.barcode_map)
         output_fastq = list(actual.sequences.iter_views(FastqGzFormat))
-        # two per-sample files were written
-        self.assertEqual(len(output_fastq), 2)
+        # five per-sample files were written
+        self.assertEqual(len(output_fastq), 5)
 
         # sequences in sample1 are correct
-        sample1_seqs = skbio.io.read(output_fastq[0][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample1_seqs = list(sample1_seqs)
-        self.assertEqual(len(sample1_seqs), 2)
-        self._compare_sequence_to_record(sample1_seqs[0], self.sequences[0])
-        self._compare_sequence_to_record(sample1_seqs[1], self.sequences[1])
+        self._validate_sample_fastq(
+            output_fastq[0][1].open(), self.sequences, [0, 5])
 
         # sequences in sample2 are correct
-        sample2_seqs = skbio.io.read(output_fastq[1][1].open(),
-                                     format='fastq',
-                                     phred_offset=33, compression='gzip',
-                                     constructor=skbio.DNA)
-        sample2_seqs = list(sample2_seqs)
-        self.assertEqual(len(sample2_seqs), 2)
-        self._compare_sequence_to_record(sample2_seqs[0], self.sequences[2])
-        self._compare_sequence_to_record(sample2_seqs[1], self.sequences[3])
+        self._validate_sample_fastq(
+            output_fastq[1][1].open(), self.sequences, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            output_fastq[2][1].open(), self.sequences, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            output_fastq[3][1].open(), self.sequences, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            output_fastq[4][1].open(), self.sequences, [6, 8, 9])
 
         # manifest is correct
         act_manifest = list(actual.manifest.view(FastqManifestFormat).open())
         exp_manifest = ['sample-id,filename,direction\n',
                         'sample1,sample1_1_L001_R1_001.fastq.gz,forward\n',
-                        'sample2,sample2_2_L001_R1_001.fastq.gz,forward\n']
+                        'sample3,sample3_2_L001_R1_001.fastq.gz,forward\n',
+                        'sample2,sample2_3_L001_R1_001.fastq.gz,forward\n',
+                        'sample5,sample5_4_L001_R1_001.fastq.gz,forward\n',
+                        'sample4,sample4_5_L001_R1_001.fastq.gz,forward\n']
         self._compare_manifests(act_manifest, exp_manifest)
 
         # metadata is correct
         act_metadata = list(actual.metadata.view(YamlFormat).open())
         exp_metadata = ["{phred-offset: 33}\n"]
         self.assertEqual(act_metadata, exp_metadata)
+
+
+class EmpPairedTests(unittest.TestCase, EmpTestingUtils):
+    def setUp(self):
+        self.barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
+                         ('@s2/2 abc/2', 'TTAA', '+', 'PPPP'),
+                         ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
+                         ('@s4/2 abc/2', 'TTAA', '+', 'PPPP'),
+                         ('@s5/2 abc/2', 'AACC', '+', 'PPPP'),
+                         ('@s6/2 abc/2', 'AAAA', '+', 'PPPP'),
+                         ('@s7/2 abc/2', 'CGGC', '+', 'PPPP'),
+                         ('@s8/2 abc/2', 'GGAA', '+', 'PPPP'),
+                         ('@s9/2 abc/2', 'CGGC', '+', 'PPPP'),
+                         ('@s10/2 abc/2', 'CGGC', '+', 'PPPP'),
+                         ('@s11/2 abc/2', 'GGAA', '+', 'PPPP')]
+
+        self.forward = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                        ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                        ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                        ('@s4/1 abc/1', 'TTT', '+', 'PPP'),
+                        ('@s5/1 abc/1', 'ATA', '+', 'PPP'),
+                        ('@s6/1 abc/1', 'TAT', '+', 'PPP'),
+                        ('@s7/1 abc/1', 'CGC', '+', 'PPP'),
+                        ('@s8/1 abc/1', 'GCG', '+', 'PPP'),
+                        ('@s9/1 abc/1', 'ACG', '+', 'PPP'),
+                        ('@s10/1 abc/1', 'GCA', '+', 'PPP'),
+                        ('@s11/1 abc/1', 'TGA', '+', 'PPP')]
+
+        self.reverse = [('@s1/1 abc/1', 'CCC', '+', 'YYY'),
+                        ('@s2/1 abc/1', 'GGG', '+', 'PPP'),
+                        ('@s3/1 abc/1', 'TTT', '+', 'PPP'),
+                        ('@s4/1 abc/1', 'AAA', '+', 'PPP'),
+                        ('@s5/1 abc/1', 'TAT', '+', 'PPP'),
+                        ('@s6/1 abc/1', 'ATA', '+', 'PPP'),
+                        ('@s7/1 abc/1', 'GCG', '+', 'PPP'),
+                        ('@s8/1 abc/1', 'CGC', '+', 'PPP'),
+                        ('@s9/1 abc/1', 'CGT', '+', 'PPP'),
+                        ('@s10/1 abc/1', 'TGC', '+', 'PPP'),
+                        ('@s11/1 abc/1', 'TCA', '+', 'PPP')]
+
+        self.bpsi = BarcodePairedSequenceFastqIterator(
+            self.barcodes, self.forward, self.reverse)
+
+        barcode_map = pd.Series(['AAAA', 'AACC', 'TTAA', 'GGAA', 'CGGC'],
+                                index=['sample1', 'sample2', 'sample3',
+                                       'sample4', 'sample5'])
+        self.barcode_map = qiime2.MetadataCategory(barcode_map)
+
+    def check_valid(self, *args, **kwargs):
+        actual = emp_paired(*args, **kwargs)
+
+        # five forward sample files
+        forward_fastq = [
+            view for path, view in actual.sequences.iter_views(FastqGzFormat)
+            if 'R1_001.fastq' in path.name]
+        self.assertEqual(len(forward_fastq), 5)
+
+        # five reverse sample files
+        reverse_fastq = [
+            view for path, view in actual.sequences.iter_views(FastqGzFormat)
+            if 'R2_001.fastq' in path.name]
+        self.assertEqual(len(reverse_fastq), 5)
+
+        # FORWARD:
+        # sequences in sample1 are correct
+        self._validate_sample_fastq(
+            forward_fastq[0].open(), self.forward, [0, 5])
+
+        # sequences in sample2 are correct
+        self._validate_sample_fastq(
+            forward_fastq[1].open(), self.forward, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            forward_fastq[2].open(), self.forward, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            forward_fastq[3].open(), self.forward, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            forward_fastq[4].open(), self.forward, [6, 8, 9])
+
+        # REVERSE:
+        # sequences in sample1 are correct
+        self._validate_sample_fastq(
+            reverse_fastq[0].open(), self.reverse, [0, 5])
+
+        # sequences in sample2 are correct
+        self._validate_sample_fastq(
+            reverse_fastq[1].open(), self.reverse, [2, 4])
+
+        # sequences in sample3 are correct
+        self._validate_sample_fastq(
+            reverse_fastq[2].open(), self.reverse, [1, 3])
+
+        # sequences in sample4 are correct
+        self._validate_sample_fastq(
+            reverse_fastq[3].open(), self.reverse, [7, 10])
+
+        # sequences in sample5 are correct
+        self._validate_sample_fastq(
+            reverse_fastq[4].open(), self.reverse, [6, 8, 9])
+
+        # manifest is correct
+        act_manifest = list(actual.manifest.view(FastqManifestFormat).open())
+        exp_manifest = ['sample-id,filename,direction\n',
+                        'sample1,sample1_1_L001_R1_001.fastq.gz,forward\n',
+                        'sample1,sample1_1_L001_R2_001.fastq.gz,reverse\n',
+                        'sample3,sample3_2_L001_R1_001.fastq.gz,forward\n',
+                        'sample3,sample3_2_L001_R2_001.fastq.gz,reverse\n',
+                        'sample2,sample2_3_L001_R1_001.fastq.gz,forward\n',
+                        'sample2,sample2_3_L001_R2_001.fastq.gz,reverse\n',
+                        'sample5,sample5_4_L001_R1_001.fastq.gz,forward\n',
+                        'sample5,sample5_4_L001_R2_001.fastq.gz,reverse\n',
+                        'sample4,sample4_5_L001_R1_001.fastq.gz,forward\n',
+                        'sample4,sample4_5_L001_R2_001.fastq.gz,reverse\n']
+
+        self._compare_manifests(act_manifest, exp_manifest)
+
+        # metadata is correct
+        act_metadata = list(actual.metadata.view(YamlFormat).open())
+        exp_metadata = ["{phred-offset: 33}\n"]
+        self.assertEqual(act_metadata, exp_metadata)
+
+    def test_valid(self):
+        self.check_valid(self.bpsi, self.barcode_map)
+
+    @mock.patch('q2_demux._demux.OPEN_FH_LIMIT', 6)
+    def test_valid_small_open_fh_limit(self):
+        self.test_valid()
+
+    def test_variable_length_barcodes(self):
+        barcodes = pd.Series(['AAA', 'AACC'], index=['sample1', 'sample2'])
+        barcodes = qiime2.MetadataCategory(barcodes)
+        with self.assertRaises(ValueError):
+            emp_paired(self.bpsi, barcodes)
+
+    def test_duplicate_barcodes(self):
+        barcodes = pd.Series(['AACC', 'AACC'], index=['sample1', 'sample2'])
+        barcodes = qiime2.MetadataCategory(barcodes)
+        with self.assertRaises(ValueError):
+            emp_paired(self.bpsi, barcodes)
+
+    def test_no_matched_barcodes(self):
+        barcodes = pd.Series(['CCCC', 'GGCC'], index=['sample1', 'sample2'])
+        barcodes = qiime2.MetadataCategory(barcodes)
+        with self.assertRaises(ValueError):
+            emp_paired(self.bpsi, barcodes)
+
+    def test_rev_comp_mapping_barcodes(self):
+        barcodes = pd.Series(['TTTT', 'GGTT', 'TTAA', 'TTCC', 'GCCG'],
+                             index=['sample1', 'sample2', 'sample3', 'sample4',
+                                    'sample5'])
+        barcodes = qiime2.MetadataCategory(barcodes)
+        self.check_valid(self.bpsi, barcodes, rev_comp_mapping_barcodes=True)
+
+    def test_rev_comp_barcodes(self):
+        barcodes = [('@s1/2 abc/2', 'TTTT', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'TTAA', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'GGTT', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAA', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'GGTT', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'TTTT', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'TTCC', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'GCCG', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'TTCC', '+', 'PPPP')]
+        bpsi = BarcodePairedSequenceFastqIterator(
+            barcodes, self.forward, self.reverse)
+        self.check_valid(bpsi, self.barcode_map, rev_comp_barcodes=True)
+
+    def test_barcode_trimming(self):
+        # these barcodes are longer then the ones in the mapping file, so
+        # only the first barcode_length bases should be read
+        barcodes = [('@s1/2 abc/2', 'AAAAG', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACCG', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'AACCG', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'AAAAG', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'GGAAG', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'CGGCG', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'GGAAG', '+', 'PPPP')]
+        bpsi = BarcodePairedSequenceFastqIterator(
+            barcodes, self.forward, self.reverse)
+        self.check_valid(bpsi, self.barcode_map)
 
 
 class SummarizeTests(unittest.TestCase):
@@ -399,7 +650,7 @@ class SummarizeTests(unittest.TestCase):
         barcode_map = pd.Series(['AAAA', 'AACC'], index=['sample1', 'sample2'])
         barcode_map = qiime2.MetadataCategory(barcode_map)
 
-        demux_data = emp(bsi, barcode_map)
+        demux_data = emp_single(bsi, barcode_map)
         # test that an index.html file is created and that it has size > 0
         with tempfile.TemporaryDirectory() as output_dir:
             result = summarize(output_dir, demux_data)
@@ -430,7 +681,7 @@ class SummarizeTests(unittest.TestCase):
         barcode_map = pd.Series(['AAAA'], index=['sample1'])
         barcode_map = qiime2.MetadataCategory(barcode_map)
 
-        demux_data = emp(bsi, barcode_map)
+        demux_data = emp_single(bsi, barcode_map)
         # test that an index.html file is created and that it has size > 0
         with tempfile.TemporaryDirectory() as output_dir:
             result = summarize(output_dir, demux_data)

--- a/q2_demux/test/test_transformer.py
+++ b/q2_demux/test/test_transformer.py
@@ -9,8 +9,8 @@
 import unittest
 import tempfile
 
-from q2_demux._format import (EMPMultiplexedDirFmt,
-                              EMPMultiplexedSingleEndDirFmt)
+from q2_demux._format import (EMPSingleEndDirFmt,
+                              EMPSingleEndCasavaDirFmt)
 from q2_demux._demux import BarcodeSequenceFastqIterator
 from qiime2.plugin.testing import TestPluginBase
 
@@ -34,11 +34,11 @@ class TestTransformers(TestPluginBase):
             prefix='q2-demux-test-temp-')
 
     def test_emp_multiplexed_format_barcode_sequence_iterator(self):
-        transformer = self.get_transformer(EMPMultiplexedDirFmt,
+        transformer = self.get_transformer(EMPSingleEndDirFmt,
                                            BarcodeSequenceFastqIterator)
         dirname = 'emp_multiplexed'
         dirpath = self.get_data_path(dirname)
-        bsi = transformer(EMPMultiplexedDirFmt(dirpath, mode='r'))
+        bsi = transformer(EMPSingleEndDirFmt(dirpath, mode='r'))
         bsi = list(bsi)
         self.assertEqual(len(bsi), 250)
         self.assertEqual(
@@ -59,15 +59,15 @@ class TestTransformers(TestPluginBase):
              'CD<CDCA>A@A>:<?B@?<((2(>?'))
 
     def test_emp_se_multiplexed_format_barcode_sequence_iterator(self):
-        transformer1 = self.get_transformer(EMPMultiplexedSingleEndDirFmt,
-                                            EMPMultiplexedDirFmt)
-        transformer2 = self.get_transformer(EMPMultiplexedDirFmt,
+        transformer1 = self.get_transformer(EMPSingleEndCasavaDirFmt,
+                                            EMPSingleEndDirFmt)
+        transformer2 = self.get_transformer(EMPSingleEndDirFmt,
                                             BarcodeSequenceFastqIterator)
         dirname = 'emp_multiplexed_single_end'
         dirpath = self.get_data_path(dirname)
         emp_demultiplexed = \
-            transformer1(EMPMultiplexedSingleEndDirFmt(dirpath, mode='r'))
-        bsi = transformer2(EMPMultiplexedDirFmt(emp_demultiplexed, mode='r'))
+            transformer1(EMPSingleEndCasavaDirFmt(dirpath, mode='r'))
+        bsi = transformer2(EMPSingleEndDirFmt(emp_demultiplexed, mode='r'))
         bsi = list(bsi)
         self.assertEqual(len(bsi), 250)
         self.assertEqual(
@@ -90,15 +90,15 @@ class TestTransformers(TestPluginBase):
     def test_invalid(self):
         dirname = 'bad'
         dirpath = self.get_data_path(dirname)
-        transformer = self.get_transformer(EMPMultiplexedDirFmt,
+        transformer = self.get_transformer(EMPSingleEndDirFmt,
                                            BarcodeSequenceFastqIterator)
         with self.assertRaises(ValueError):
-            transformer(EMPMultiplexedDirFmt(dirpath, mode='r'))
+            transformer(EMPSingleEndDirFmt(dirpath, mode='r'))
 
-        transformer = self.get_transformer(EMPMultiplexedSingleEndDirFmt,
-                                           EMPMultiplexedDirFmt)
+        transformer = self.get_transformer(EMPSingleEndCasavaDirFmt,
+                                           EMPSingleEndDirFmt)
         with self.assertRaises(ValueError):
-            transformer(EMPMultiplexedSingleEndDirFmt(dirpath, 'r'))
+            transformer(EMPSingleEndCasavaDirFmt(dirpath, 'r'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a bug in which in order to limit the number of filehandles, the
wrong path would be reopened, resulting in reads being placed in the wrong
sample file.

Necessary formats and objects added to support emp_paired method.