### PR TITLE
BUG: Ensure uniform sequence lengths in `summarize`

### DIFF
--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -212,6 +212,8 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         fh.write(');')
 
 
-inconsistent_length_template = ('Encountered sequences of length %s and %s. '
-                                'Demux does not support inconsistent sequence '
-                                'lengths at this time.')
+inconsistent_length_template = ('Observed sequences of length %s '
+                                'and %s while generating a random '
+                                'subsample of sequences. Inconsistent '
+                                'length sequences are not supported '
+                                'in this visualization at this time.')

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -59,14 +59,14 @@ def _subsample_paired(fastq_map):
     for fwd, rev, index in fastq_map:
         file_pair = zip(_read_fastq_seqs(fwd), _read_fastq_seqs(rev))
         for i, (fseq, rseq) in enumerate(file_pair):
-            if not seq_len:
+            if seq_len is None:
                 seq_len = len(fseq[1])
             if seq_len != len(fseq[1]):
                 raise ValueError(inconsistent_length_template
-                                 % (str(seq_len), str(len(fseq[1]))))
+                                 % (seq_len, len(fseq[1])))
             if seq_len != len(rseq[1]):
                 raise ValueError(inconsistent_length_template
-                                 % (str(seq_len), str(len(rseq[1]))))
+                                 % (seq_len, len(rseq[1])))
             if i == index[0]:
                 qual_sample['forward'].append(_decode_qual_to_phred33(fseq[3]))
                 qual_sample['reverse'].append(_decode_qual_to_phred33(rseq[3]))
@@ -82,11 +82,11 @@ def _subsample_single(fastq_map):
     seq_len = None
     for file, index in fastq_map:
         for i, seq in enumerate(_read_fastq_seqs(file)):
-            if not seq_len:
+            if seq_len is None:
                 seq_len = len(seq[1])
             if seq_len != len(seq[1]):
                 raise ValueError(inconsistent_length_template
-                                 % (str(seq_len), str(len(seq[1]))))
+                                 % (seq_len, len(seq[1])))
             if i == index[0]:
                 qual_sample['forward'].append(_decode_qual_to_phred33(seq[3]))
                 index.pop(0)
@@ -123,7 +123,6 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         count = 0
         for seq in _read_fastq_seqs(file):
             count += 1
-
         sample_name = os.path.basename(file).split('_', 1)[0]
         per_sample_fastq_counts[sample_name] = count
 
@@ -212,8 +211,8 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         fh.write(');')
 
 
-inconsistent_length_template = ('Observed sequences of length %s '
-                                'and %s while generating a random '
+inconsistent_length_template = ('Observed sequences of length %d '
+                                'and %d while generating a random '
                                 'subsample of sequences. Inconsistent '
                                 'length sequences are not supported '
                                 'in this visualization at this time.')

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -62,13 +62,11 @@ def _subsample_paired(fastq_map):
             if not seq_len:
                 seq_len = len(fseq[1])
             if seq_len != len(fseq[1]):
-                raise ValueError('Encountered inconsistent length '
-                                 'sequence in %s.'
-                                 % os.path.basename(fwd))
+                raise ValueError(inconsistent_length_template
+                                 % (str(seq_len), str(len(fseq[1]))))
             if seq_len != len(rseq[1]):
-                raise ValueError('Encountered inconsistent length '
-                                 'sequence in %s.'
-                                 % os.path.basename(rev))
+                raise ValueError(inconsistent_length_template
+                                 % (str(seq_len), str(len(rseq[1]))))
             if i == index[0]:
                 qual_sample['forward'].append(_decode_qual_to_phred33(fseq[3]))
                 qual_sample['reverse'].append(_decode_qual_to_phred33(rseq[3]))
@@ -87,9 +85,8 @@ def _subsample_single(fastq_map):
             if not seq_len:
                 seq_len = len(seq[1])
             if seq_len != len(seq[1]):
-                raise ValueError('Encountered inconsistent length '
-                                 'sequence in %s.'
-                                 % os.path.basename(file))
+                raise ValueError(inconsistent_length_template
+                                 % (str(seq_len), str(len(seq[1]))))
             if i == index[0]:
                 qual_sample['forward'].append(_decode_qual_to_phred33(seq[3]))
                 index.pop(0)
@@ -213,3 +210,8 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
             fh.write(',')
             reverse_stats.to_json(fh)
         fh.write(');')
+
+
+inconsistent_length_template = ('Encountered sequences of length %s and %s. '
+                                'Demux does not support inconsistent sequence '
+                                'lengths at this time.')

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -655,8 +655,8 @@ class SummarizeTests(unittest.TestCase):
 
         demux_data = emp_single(bsi, barcode_map)
         # test that an index.html file is created and that it has size > 0
-        # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
+            # TODO: Remove _PlotQualView wrapper
             result = summarize(output_dir, _PlotQualView(demux_data,
                                                          paired=False), n=2)
             self.assertTrue(result is None)
@@ -686,8 +686,8 @@ class SummarizeTests(unittest.TestCase):
 
         demux_data = emp_single(bsi, barcode_map)
         # test that an index.html file is created and that it has size > 0
-        # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
+            # TODO: Remove _PlotQualView wrapper
             result = summarize(output_dir, _PlotQualView(demux_data,
                                                          paired=False), n=1)
             self.assertTrue(result is None)
@@ -776,32 +776,32 @@ class SummarizeTests(unittest.TestCase):
                 self.assertIn('<strong>Danger:</strong>', html)
 
     def test_inconsistent_sequence_length_single(self):
-        sequences = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
-                     ('@s2/1 abc/1', 'CC', '+', 'PPP'),
-                     ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
-                     ('@s4/1 abc/1', 'TTT', '+', 'PPP')]
+        sequences = [('@s1/1 abc/1', 'GGGG', '+', 'YYYY'),
+                     ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                     ('@s3/1 abc/1', 'AA', '+', 'PP'),
+                     ('@s4/1 abc/1', 'T', '+', 'P')]
         bsi = BarcodeSequenceFastqIterator(self.barcodes, sequences)
 
         barcode_map = pd.Series(['AAAA', 'AACC'], index=['sample1', 'sample2'])
         barcode_map = qiime2.MetadataCategory(barcode_map)
 
         demux_data = emp_single(bsi, barcode_map)
-        # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
             with self.assertRaisesRegex(ValueError,
                                         'Observed sequences of length'):
+                # TODO: Remove _PlotQualView wrapper
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=False), n=2)
 
     def test_inconsistent_sequence_length_paired(self):
-        forward = [('@s1/1 abc/1', 'G', '+', 'YYY'),
-                   ('@s2/1 abc/1', 'CC', '+', 'PPP'),
+        forward = [('@s1/1 abc/1', 'G', '+', 'Y'),
+                   ('@s2/1 abc/1', 'CC', '+', 'PP'),
                    ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
-                   ('@s4/1 abc/1', 'TTTT', '+', 'PPP')]
-        reverse = [('@s1/1 abc/1', 'AAAA', '+', 'YYY'),
+                   ('@s4/1 abc/1', 'TTTT', '+', 'PPPP')]
+        reverse = [('@s1/1 abc/1', 'AAAA', '+', 'YYYY'),
                    ('@s2/1 abc/1', 'TTT', '+', 'PPP'),
-                   ('@s3/1 abc/1', 'GG', '+', 'PPP'),
-                   ('@s4/1 abc/1', 'C', '+', 'PPP')]
+                   ('@s3/1 abc/1', 'GG', '+', 'PP'),
+                   ('@s4/1 abc/1', 'C', '+', 'P')]
         bpsi = BarcodePairedSequenceFastqIterator(self.barcodes, forward,
                                                   reverse)
 
@@ -809,10 +809,10 @@ class SummarizeTests(unittest.TestCase):
         barcode_map = qiime2.MetadataCategory(barcode_map)
 
         demux_data = emp_paired(bpsi, barcode_map)
-        # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
             with self.assertRaisesRegex(ValueError,
                                         'Observed sequences of length'):
+                # TODO: Remove _PlotQualView wrapper
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=True), n=2)
 

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -788,8 +788,8 @@ class SummarizeTests(unittest.TestCase):
         demux_data = emp_single(bsi, barcode_map)
         # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
-            with self.assertRaisesRegex(ValueError, 
-                                        'Encountered sequences of length'):
+            with self.assertRaisesRegex(ValueError,
+                                        'Observed sequences of length'):
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=False), n=2)
 
@@ -811,8 +811,8 @@ class SummarizeTests(unittest.TestCase):
         demux_data = emp_paired(bpsi, barcode_map)
         # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
-            with self.assertRaisesRegex(ValueError, 
-                                        'Encountered sequences of length'):
+            with self.assertRaisesRegex(ValueError,
+                                        'Observed sequences of length'):
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=True), n=2)
 

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -788,7 +788,8 @@ class SummarizeTests(unittest.TestCase):
         demux_data = emp_single(bsi, barcode_map)
         # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
-            with self.assertRaisesRegex(ValueError, 'inconsistent length'):
+            with self.assertRaisesRegex(ValueError, 
+                                        'Encountered sequences of length'):
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=False), n=2)
 
@@ -810,7 +811,8 @@ class SummarizeTests(unittest.TestCase):
         demux_data = emp_paired(bpsi, barcode_map)
         # TODO: Remove _PlotQualView wrapper
         with tempfile.TemporaryDirectory() as output_dir:
-            with self.assertRaisesRegex(ValueError, 'inconsistent length'):
+            with self.assertRaisesRegex(ValueError, 
+                                        'Encountered sequences of length'):
                 summarize(output_dir, _PlotQualView(demux_data,
                                                     paired=True), n=2)
 


### PR DESCRIPTION
Fixes #41

Pair-programmed with @thermokarst

**Question for reviewer**: we currently don't walk over the reverse sequences for paired-end data.  As a result, if the reverse sequences for some reason did not have constant sequence-length, but the forward sequences did, no `ValueError` would be raised.  Do we want to address this edge case, at the expense of speed (a second, likely redundant file to step over), or is checking the forward sequences sufficient?