### PR TITLE
Export quality data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# idea IDE config data
+.idea
 # C extensions
 *.so
 

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -150,8 +150,8 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
     forward_scores = pd.DataFrame(quality_scores['forward'])
     forward_stats = _compute_stats_of_df(forward_scores)
     forward_stats.to_csv(os.path.join(output_dir,
-                                      'forward-index-quality-scores.csv'),
-                                      header=True, index=True)
+                         'forward-index-quality-scores.csv'),
+                         header=True, index=True)
 
     if (forward_stats.loc['50%'] > 45).any():
         dangers.append('Some of the PHRED quality values are out of range. '
@@ -163,8 +163,8 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         reverse_scores = pd.DataFrame(quality_scores['reverse'])
         reverse_stats = _compute_stats_of_df(reverse_scores)
         reverse_stats.to_csv(os.path.join(output_dir,
-                                          'reverse-index-quality-scores.csv'),
-                                          header=True, index=True)
+                             'reverse-index-quality-scores.csv'),
+                             header=True, index=True)
 
     show_plot = len(fwd) > 1
     if show_plot:

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -149,6 +149,9 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
 
     forward_scores = pd.DataFrame(quality_scores['forward'])
     forward_stats = _compute_stats_of_df(forward_scores)
+    forward_stats.to_csv(os.path.join(output_dir,
+                                      'forward-index-quality-scores.csv'),
+                                      header=True, index=True)
 
     if (forward_stats.loc['50%'] > 45).any():
         dangers.append('Some of the PHRED quality values are out of range. '
@@ -159,6 +162,9 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
     if paired:
         reverse_scores = pd.DataFrame(quality_scores['reverse'])
         reverse_stats = _compute_stats_of_df(reverse_scores)
+        reverse_stats.to_csv(os.path.join(output_dir,
+                                          'reverse-index-quality-scores.csv'),
+                                          header=True, index=True)
 
     show_plot = len(fwd) > 1
     if show_plot:

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -150,7 +150,7 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
     forward_scores = pd.DataFrame(quality_scores['forward'])
     forward_stats = _compute_stats_of_df(forward_scores)
     forward_stats.to_csv(os.path.join(output_dir,
-                         'forward-index-quality-scores.csv'),
+                         'forward-seven-number-summaries.csv'),
                          header=True, index=True)
 
     if (forward_stats.loc['50%'] > 45).any():
@@ -163,7 +163,7 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         reverse_scores = pd.DataFrame(quality_scores['reverse'])
         reverse_stats = _compute_stats_of_df(reverse_scores)
         reverse_stats.to_csv(os.path.join(output_dir,
-                             'reverse-index-quality-scores.csv'),
+                             'reverse-seven-number-summaries.csv'),
                              header=True, index=True)
 
     show_plot = len(fwd) > 1

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -64,14 +64,14 @@
     <h5 class="text-center">Reverse Reads</h5>
     <div class="row">
       <div class="col-lg-12">
-        <a href="forward-index-quality-scores.cs">
+        <a href="forward-seven-number-summaries.csv">
           Download forward parametric seven-number summaries as CSV
         </a>
       </div>
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <a href="reverse-index-quality-scores.cs'">
+        <a href="reverse-seven-number-summaries.csv">
           Download reverse parametric seven-number summaries as CSV
         </a>
       </div>
@@ -81,7 +81,7 @@
   <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3">
       <div class="row">
         <div class="col-lg-12">
-          <a href="reverse-index-quality-scores.csv">
+          <a href="forward-seven-number-summaries.csv">
             Download forward parametric seven-number summaries as CSV
           </a>
         </div>

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -67,6 +67,11 @@
   <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3"></div>
   {% endif %}
 </div>
+<div class="row">
+  <div class="col-lg-12">
+    <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
+  </div>
+</div>
 <script src="./dist/bundle.js" charset="utf-8"></script>
 <script src="./data.jsonp" charset="utf-8"></script>
 {% endblock %}

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -63,14 +63,24 @@
   <div id="reverseContainer" class="col-xs-12 col-md-6">
     <h5 class="text-center">Reverse Reads</h5>
   </div>
+  <div class="row">
+    <div class="col-lg-12">
+      <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
+    </div>
+  </div>
+  <div class="row">
+      <div class="col-lg-12">
+        <a href="reverse-index-quality-scores.csv'">Download reverse counts as CSV</a>
+      </div>
+  </div>
   {% else %}
   <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3"></div>
-  {% endif %}
-</div>
-<div class="row">
-  <div class="col-lg-12">
-    <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
+  <div class="row">
+    <div class="col-lg-12">
+      <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
+    </div>
   </div>
+  {% endif %}
 </div>
 <script src="./dist/bundle.js" charset="utf-8"></script>
 <script src="./data.jsonp" charset="utf-8"></script>

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -64,14 +64,14 @@
     <h5 class="text-center">Reverse Reads</h5>
     <div class="row">
       <div class="col-lg-12">
-        <a href="forward-index-quality-scores.csv">
+        <a href="forward-index-quality-scores.cs">
           Download forward parametric seven-number summaries as CSV
         </a>
       </div>
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <a href="reverse-index-quality-scores.csv'">
+        <a href="reverse-index-quality-scores.cs'">
           Download reverse parametric seven-number summaries as CSV
         </a>
       </div>
@@ -81,7 +81,7 @@
   <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3">
       <div class="row">
         <div class="col-lg-12">
-          <a href="forward-index-quality-scores.csv">
+          <a href="reverse-index-quality-scores.csv">
             Download forward parametric seven-number summaries as CSV
           </a>
         </div>

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -62,31 +62,9 @@
   </div>
   <div id="reverseContainer" class="col-xs-12 col-md-6">
     <h5 class="text-center">Reverse Reads</h5>
-    <div class="row">
-      <div class="col-lg-12">
-        <a href="forward-seven-number-summaries.csv">
-          Download forward parametric seven-number summaries as CSV
-        </a>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-lg-12">
-        <a href="reverse-seven-number-summaries.csv">
-          Download reverse parametric seven-number summaries as CSV
-        </a>
-      </div>
-    </div>
   </div>
   {% else %}
-  <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3">
-      <div class="row">
-        <div class="col-lg-12">
-          <a href="forward-seven-number-summaries.csv">
-            Download forward parametric seven-number summaries as CSV
-          </a>
-        </div>
-      </div>
-  </div>
+  <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3"></div>
   {% endif %}
 </div>
 <script src="./dist/bundle.js" charset="utf-8"></script>

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -62,23 +62,30 @@
   </div>
   <div id="reverseContainer" class="col-xs-12 col-md-6">
     <h5 class="text-center">Reverse Reads</h5>
-  </div>
-  <div class="row">
-    <div class="col-lg-12">
-      <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
-    </div>
-  </div>
-  <div class="row">
+    <div class="row">
       <div class="col-lg-12">
-        <a href="reverse-index-quality-scores.csv'">Download reverse counts as CSV</a>
+        <a href="forward-index-quality-scores.csv">
+          Download forward parametric seven-number summaries as CSV
+        </a>
       </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-12">
+        <a href="reverse-index-quality-scores.csv'">
+          Download reverse parametric seven-number summaries as CSV
+        </a>
+      </div>
+    </div>
   </div>
   {% else %}
-  <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3"></div>
-  <div class="row">
-    <div class="col-lg-12">
-      <a href="forward-index-quality-scores.csv">Download forward quality as CSV</a>
-    </div>
+  <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3">
+      <div class="row">
+        <div class="col-lg-12">
+          <a href="forward-index-quality-scores.csv">
+            Download forward parametric seven-number summaries as CSV
+          </a>
+        </div>
+      </div>
   </div>
   {% endif %}
 </div>

--- a/q2_demux/_summarize/assets/src/plot.js
+++ b/q2_demux/_summarize/assets/src/plot.js
@@ -80,6 +80,12 @@ const plot = (data, props, container, seqProps) => {
     .append('td')
     .text(d => d);
 
+  plotContainer
+    .append('div')
+      .attr('class', 'col-xs-12')
+    .append('div')
+      .html(`<a href="${data.direction}-seven-number-summaries.csv">Download ${data.direction} parametric seven-number summaries as CSV</a>`)
+
   const maxX = d3.max(data, d => d[0]) + 1;
   const x0 = [0, maxX];
   const y0 = [0, 45];

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -702,9 +702,8 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertTrue(os.path.exists(png_fp))
             self.assertTrue(os.path.getsize(png_fp) > 0)
-            qual_forward_fp = os.path.join(output_dir,
-                                           'forward-seven-number-summaries'
-                                           '.csv')
+            qual_forward_fp = os.path.join(
+                output_dir, 'forward-seven-number-summaries.csv')
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
@@ -808,14 +807,12 @@ class SummarizeTests(TestPluginBase):
                                                          paired=True), n=2)
             self.assertTrue(result is None)
             plot_fp = os.path.join(output_dir, 'quality-plot.html')
-            qual_forward_fp = os.path.join(output_dir,
-                                           'forward-seven-number-summaries'
-                                           '.csv')
+            qual_forward_fp = os.path.join(
+                output_dir, 'forward-seven-number-summaries.csv')
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
-            qual_reverse_fp = os.path.join(output_dir,
-                                           'reverse-seven-number-summaries'
-                                           '.csv')
+            qual_reverse_fp = os.path.join(
+                output_dir, 'reverse-seven-number-summaries.csv')
             self.assertTrue(os.path.exists(qual_reverse_fp))
             self.assertTrue(os.path.getsize(qual_reverse_fp) > 0)
             with open(plot_fp, 'r') as fh:

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -680,7 +680,8 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertTrue(os.path.exists(png_fp))
             self.assertTrue(os.path.getsize(png_fp) > 0)
-            qual_forward_fp = os.path.join(output_dir, 'forward-index-quality-scores.csv')
+            qual_forward_fp = os.path.join(output_dir,
+                                           'forward-index-quality-scores.csv')
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -680,6 +680,9 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertTrue(os.path.exists(png_fp))
             self.assertTrue(os.path.getsize(png_fp) > 0)
+            qual_forward_fp = os.path.join(output_dir, 'forward-index-quality-scores.csv')
+            self.assertTrue(os.path.exists(qual_forward_fp))
+            self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
                 html = fh.read()
                 self.assertIn('<td>Minimum:</td><td>1</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -681,7 +681,8 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(png_fp))
             self.assertTrue(os.path.getsize(png_fp) > 0)
             qual_forward_fp = os.path.join(output_dir,
-                                           'forward-index-quality-scores.csv')
+                                           'forward-seven-number-summaries'
+                                           '.csv')
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
@@ -780,6 +781,16 @@ class SummarizeTests(TestPluginBase):
                                                          paired=True), n=2)
             self.assertTrue(result is None)
             plot_fp = os.path.join(output_dir, 'quality-plot.html')
+            qual_forward_fp = os.path.join(output_dir,
+                                           'forward-seven-number-summaries'
+                                           '.csv')
+            self.assertTrue(os.path.exists(qual_forward_fp))
+            self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
+            qual_reverse_fp = os.path.join(output_dir,
+                                           'reverse-seven-number-summaries'
+                                           '.csv')
+            self.assertTrue(os.path.exists(qual_reverse_fp))
+            self.assertTrue(os.path.getsize(qual_reverse_fp) > 0)
             with open(plot_fp, 'r') as fh:
                 html = fh.read()
                 self.assertIn('<h5 class="text-center">Forward Reads</h5>',


### PR DESCRIPTION
This allows allows users to download the data plotted in the interactive quality plot of demux summary page as a csv. It can be downloaded by clicking a link on the page, or by running `qiime tools export` on the qzv. 

Developed with regards to these posts on q2 forum
<https://forum.qiime2.org/t/export-demux-interactive-quality-plots-as-csv/2431/7>
<https://forum.qiime2.org/t/raw-quality-data/1702>

---

Fixes #63