### PR TITLE
BUG: Stop truncating y-axis label on summarize

### DIFF
--- a/q2_demux/_summarize/assets/src/plot.js
+++ b/q2_demux/_summarize/assets/src/plot.js
@@ -137,7 +137,7 @@ const plot = (data, props, container, seqProps) => {
   svg.append('text')
       .attr('transform', 'rotate(-90)')
       .attr('x', 0 - (props.height / 2))
-      .attr('dy', '0em')
+      .attr('dy', '1em')
       .attr('font-size', '12px')
       .style('text-anchor', 'middle')
       .text('Quality Score');
@@ -152,7 +152,7 @@ const plot = (data, props, container, seqProps) => {
 };
 
 const initializePlot = (data, seqProps) => {
-  const margin = { top: 10, right: 30, bottom: 30, left: 30 };
+  const margin = { top: 10, right: 30, bottom: 30, left: 40 };
   const width = d3.select('#forwardContainer').node().offsetWidth;
   const props = {
     margin,


### PR DESCRIPTION
Fixes #79 

---

Before:
<img width="796" alt="screen shot 2018-04-25 at 2 16 01 pm" src="https://user-images.githubusercontent.com/274668/39273301-3b5aedf2-4893-11e8-8e14-46757285178d.png">

After:
<img width="789" alt="screen shot 2018-04-25 at 2 16 30 pm" src="https://user-images.githubusercontent.com/274668/39273312-46e81dc0-4893-11e8-8c89-546631d4c501.png">

---

Before:
<img width="1651" alt="screen shot 2018-04-25 at 2 17 03 pm" src="https://user-images.githubusercontent.com/274668/39273338-5b9e923a-4893-11e8-8e14-577516702f92.png">

After:
<img width="1640" alt="screen shot 2018-04-25 at 2 17 30 pm" src="https://user-images.githubusercontent.com/274668/39273360-6e6c9ab0-4893-11e8-94ad-a969f27447fd.png">