### PR TITLE
ENH: Add read length seven-number summary

### DIFF
--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -95,7 +95,7 @@ def _compute_stats_of_df(df):
     return df_stats
 
 
-def _build_seq_len_table(qscores: pd.Series) -> str:
+def _build_seq_len_table(qscores: pd.DataFrame) -> str:
     sequence_lengths = qscores.notnull().sum(axis=1).copy()
     sequence_length_stats = _compute_stats_of_df(sequence_lengths)
 

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -97,12 +97,15 @@ def _compute_stats_of_df(df):
 
 def _build_seq_len_table(qscores: pd.DataFrame) -> str:
     sequence_lengths = qscores.notnull().sum(axis=1).copy()
-    sequence_length_stats = _compute_stats_of_df(sequence_lengths)
+    stats = _compute_stats_of_df(sequence_lengths)
 
-    sequence_length_stats.rename(index={'50%': '50% (Median)',
-                                        'count': 'Total Sequences Sampled'},
-                                 inplace=True)
-    frame = sequence_length_stats.to_frame(name="")
+    stats[stats.index != 'count'] = \
+        stats[stats.index != 'count'].astype(int).apply('{} nts'.format)
+
+    stats.rename(index={'50%': '50% (Median)',
+                        'count': 'Total Sequences Sampled'},
+                 inplace=True)
+    frame = stats.to_frame(name="")
     return q2templates.df_to_html(frame)
 
 

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -206,6 +206,7 @@ def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
         'forward_length_table': forward_length_table,
         'reverse_length_table': reverse_length_table,
         'result': html,
+        'n_samples': result.count(),
         'show_plot': show_plot,
         'paired': paired,
         'tabs': [{'title': 'Overview',

--- a/q2_demux/_summarize/assets/overview.html
+++ b/q2_demux/_summarize/assets/overview.html
@@ -27,6 +27,24 @@
 
 <div class="row">
     <div class="col-lg-12">
+        <h1>Demultiplexed sequence length summary</h1>
+        {% set colsize = 6 if reverse_length_table else 12 %}
+        <div class="col-lg-{{ colsize }}">
+            <h4>Forward Reads</h4>
+            {{ forward_length_table }}
+        </div>
+        {% if reverse_length_table %}
+        <div class="col-lg-{{ colsize }}">
+            <h4>Reverse Reads</h4>
+            {{ reverse_length_table }}
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+
+<div class="row">
+    <div class="col-lg-12">
         <h1>Per-sample sequence counts</h1>
         {{ result }}
         <a href="per-sample-fastq-counts.csv">Download as CSV</a>

--- a/q2_demux/_summarize/assets/overview.html
+++ b/q2_demux/_summarize/assets/overview.html
@@ -46,6 +46,7 @@
 <div class="row">
     <div class="col-lg-12">
         <h1>Per-sample sequence counts</h1>
+        <h4>Total Samples: {{ n_samples }}</h4>
         {{ result }}
         <a href="per-sample-fastq-counts.csv">Download as CSV</a>
     </div>

--- a/q2_demux/_summarize/assets/overview.html
+++ b/q2_demux/_summarize/assets/overview.html
@@ -27,24 +27,6 @@
 
 <div class="row">
     <div class="col-lg-12">
-        <h1>Demultiplexed sequence length summary</h1>
-        {% set colsize = 6 if reverse_length_table else 12 %}
-        <div class="col-lg-{{ colsize }}">
-            <h4>Forward Reads</h4>
-            {{ forward_length_table }}
-        </div>
-        {% if reverse_length_table %}
-        <div class="col-lg-{{ colsize }}">
-            <h4>Reverse Reads</h4>
-            {{ reverse_length_table }}
-        </div>
-        {% endif %}
-    </div>
-</div>
-
-
-<div class="row">
-    <div class="col-lg-12">
         <h1>Per-sample sequence counts</h1>
         <h4>Total Samples: {{ n_samples }}</h4>
         {{ result }}

--- a/q2_demux/_summarize/assets/quality-plot.html
+++ b/q2_demux/_summarize/assets/quality-plot.html
@@ -67,6 +67,24 @@
   <div id="forwardContainer" class="col-xs-12 col-md-6 col-md-offset-3"></div>
   {% endif %}
 </div>
+
+<div class="row">
+  <div class="col-lg-6 col-lg-offset-3">
+      <h1>Demultiplexed sequence length summary</h1>
+      {% set colsize = 6 if reverse_length_table else 12 %}
+      <div class="col-lg-{{ colsize }}">
+          <h4>Forward Reads</h4>
+          {{ forward_length_table }}
+      </div>
+      {% if reverse_length_table %}
+      <div class="col-lg-{{ colsize }}">
+          <h4>Reverse Reads</h4>
+          {{ reverse_length_table }}
+      </div>
+      {% endif %}
+  </div>
+</div>
+
 <script src="./dist/bundle.js" charset="utf-8"></script>
 <script src="./data.jsonp" charset="utf-8"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes #71 

---

Wasn't sure where to place the results, so I ended up just putting it on the main overview page.

Previews:

- Moving Pictures (heavily chopped fastqs)

![image](https://user-images.githubusercontent.com/2638727/41138764-50212252-6a98-11e8-8b74-1fd11dab98d8.png)

- Atacama

![image](https://user-images.githubusercontent.com/2638727/41138727-24d1f004-6a98-11e8-990f-ba9dc09c5bb3.png)


---

TODO:

- [x] Add total sample count

![image](https://user-images.githubusercontent.com/2638727/41139228-38c7d9b8-6a9b-11e8-9664-ec0f3e01effd.png)
