### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -242,8 +242,8 @@ def _write_metadata_yaml(dir_fmt):
 
 def emp_single(seqs: BarcodeSequenceFastqIterator,
                barcodes: qiime2.CategoricalMetadataColumn,
-               rev_comp_barcodes: bool=False,
-               rev_comp_mapping_barcodes: bool=False
+               rev_comp_barcodes: bool = False,
+               rev_comp_mapping_barcodes: bool = False
                ) -> SingleLanePerSampleSingleEndFastqDirFmt:
 
     result = SingleLanePerSampleSingleEndFastqDirFmt()
@@ -315,8 +315,8 @@ def emp_single(seqs: BarcodeSequenceFastqIterator,
 
 def emp_paired(seqs: BarcodePairedSequenceFastqIterator,
                barcodes: qiime2.CategoricalMetadataColumn,
-               rev_comp_barcodes: bool=False,
-               rev_comp_mapping_barcodes: bool=False
+               rev_comp_barcodes: bool = False,
+               rev_comp_mapping_barcodes: bool = False
                ) -> SingleLanePerSamplePairedEndFastqDirFmt:
 
     result = SingleLanePerSamplePairedEndFastqDirFmt()

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -109,7 +109,7 @@ def _build_seq_len_table(qscores: pd.DataFrame) -> str:
     return q2templates.df_to_html(frame)
 
 
-def summarize(output_dir: str, data: _PlotQualView, n: int=10000) -> None:
+def summarize(output_dir: str, data: _PlotQualView, n: int = 10000) -> None:
     paired = data.paired
     data = data.directory_format
     dangers = []

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.