### PR TITLE
MAINT: Improve warning to include no golay stipulation

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -330,8 +330,8 @@ def emp_single(seqs: BarcodeSequenceFastqIterator,
                          'your barcodes are in the correct orientation (see '
                          'the rev_comp_barcodes and/or '
                          'rev_comp_mapping_barcodes options). If barcodes are '
-                         'NOT Golay format provide no_golay_error_correction '
-                         'parameter.')
+                         'NOT Golay format set golay_error_correction '
+                         'to False.')
 
     for fh in per_sample_fastqs.values():
         fh.close()
@@ -450,8 +450,8 @@ def emp_paired(seqs: BarcodePairedSequenceFastqIterator,
                          'your barcodes are in the correct orientation (see '
                          'the rev_comp_barcodes and/or '
                          'rev_comp_mapping_barcodes options). If barcodes are '
-                         'NOT Golay format provide no_golay_error_correction '
-                         'parameter.')
+                         'NOT Golay format set golay_error_correction '
+                         'to False.')
 
     for fwd, rev in per_sample_fastqs.values():
         fwd.close()

--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -329,7 +329,9 @@ def emp_single(seqs: BarcodeSequenceFastqIterator,
         raise ValueError('No sequences were mapped to samples. Check that '
                          'your barcodes are in the correct orientation (see '
                          'the rev_comp_barcodes and/or '
-                         'rev_comp_mapping_barcodes options).')
+                         'rev_comp_mapping_barcodes options). If barcodes are '
+                         'NOT Golay format provide no_golay_error_correction '
+                         'parameter.')
 
     for fh in per_sample_fastqs.values():
         fh.close()
@@ -447,7 +449,9 @@ def emp_paired(seqs: BarcodePairedSequenceFastqIterator,
         raise ValueError('No sequences were mapped to samples. Check that '
                          'your barcodes are in the correct orientation (see '
                          'the rev_comp_barcodes and/or '
-                         'rev_comp_mapping_barcodes options).')
+                         'rev_comp_mapping_barcodes options). If barcodes are '
+                         'NOT Golay format provide no_golay_error_correction '
+                         'parameter.')
 
     for fwd, rev in per_sample_fastqs.values():
         fwd.close()


### PR DESCRIPTION
Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

Closes #107, Added no Golay stipulation to error message on `emp_single` and `emp_paired`. 

Error now says: 
```
'No sequences were mapped to samples. Check that '
'your barcodes are in the correct orientation (see '
'the rev_comp_barcodes and/or '
'rev_comp_mapping_barcodes options). If barcodes are '
'NOT Golay format provide no_golay_error_correction '
'parameter.'
```
