### PR TITLE
Optionally ignore mismatch in sequence record descriptions

### DIFF
--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -76,7 +76,8 @@ plugin.methods.register_function(
     parameters={'barcodes': MetadataColumn[Categorical],
                 'golay_error_correction': Bool,
                 'rev_comp_barcodes': Bool,
-                'rev_comp_mapping_barcodes': Bool},
+                'rev_comp_mapping_barcodes': Bool,
+                'ignore_description_mismatch': Bool},
     outputs=[('per_sample_sequences', SampleData[SequencesWithQuality]),
              ('error_correction_details', ErrorCorrectionDetails)],
     input_descriptions={
@@ -91,7 +92,9 @@ plugin.methods.register_function(
                              'reverse complemented prior to demultiplexing.',
         'rev_comp_mapping_barcodes': 'If provided, the barcode sequences in '
                                      'the sample metadata will be reverse '
-                                     'complemented prior to demultiplexing.'
+                                     'complemented prior to demultiplexing.',
+        'ignore_description_mismatch': 'If True, ignore mismatches in '
+                                       'sequence record description fields.'
     },
     output_descriptions={
         'per_sample_sequences': 'The resulting demultiplexed sequences.',
@@ -115,7 +118,8 @@ plugin.methods.register_function(
     parameters={'barcodes': MetadataColumn[Categorical],
                 'golay_error_correction': Bool,
                 'rev_comp_barcodes': Bool,
-                'rev_comp_mapping_barcodes': Bool},
+                'rev_comp_mapping_barcodes': Bool,
+                'ignore_description_mismatch': Bool},
     outputs=[
         ('per_sample_sequences', SampleData[PairedEndSequencesWithQuality]),
         ('error_correction_details', ErrorCorrectionDetails),
@@ -132,7 +136,9 @@ plugin.methods.register_function(
                              'reverse complemented prior to demultiplexing.',
         'rev_comp_mapping_barcodes': 'If provided, the barcode sequences in '
                                      'the sample metadata will be reverse '
-                                     'complemented prior to demultiplexing.'
+                                     'complemented prior to demultiplexing.',
+        'ignore_description_mismatch': 'If True, ignore mismatches in '
+                                       'sequence record description fields.'
     },
     output_descriptions={
         'per_sample_sequences': 'The resulting demultiplexed sequences.',

--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -93,7 +93,7 @@ plugin.methods.register_function(
         'rev_comp_mapping_barcodes': 'If provided, the barcode sequences in '
                                      'the sample metadata will be reverse '
                                      'complemented prior to demultiplexing.',
-        'ignore_description_mismatch': 'If True, ignore mismatches in '
+        'ignore_description_mismatch': 'If enabled, ignore mismatches in '
                                        'sequence record description fields.'
     },
     output_descriptions={

--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -137,7 +137,7 @@ plugin.methods.register_function(
         'rev_comp_mapping_barcodes': 'If provided, the barcode sequences in '
                                      'the sample metadata will be reverse '
                                      'complemented prior to demultiplexing.',
-        'ignore_description_mismatch': 'If True, ignore mismatches in '
+        'ignore_description_mismatch': 'If enabled, ignore mismatches in '
                                        'sequence record description fields.'
     },
     output_descriptions={

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -105,6 +105,21 @@ class BarcodeSequenceFastqIteratorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             list(bsi)
 
+    def test_mismatch_description_override(self):
+        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'AAAA', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'AACC', '+', 'PPPP')]
+
+        sequences = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                     ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                     ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                     ('@s4/1 abd/1', 'TTT', '+', 'PPP')]
+
+        bsi = BarcodeSequenceFastqIterator(barcodes, sequences,
+                                           ignore_description_mismatch=True)
+        self.assertEqual(len(list(bsi)), 4)
+
     def test_mismatched_handles_slashes_in_id(self):
         # mismatch is detected as being before the last slash, even if there
         # is more than one slash
@@ -790,6 +805,46 @@ class EmpPairedTests(unittest.TestCase, EmpTestingUtils):
         barcodes = qiime2.CategoricalMetadataColumn(barcodes)
         self.check_valid(self.bpsi, barcodes, rev_comp_mapping_barcodes=True,
                          golay_error_correction=False)
+
+    def test_mismatched_description(self):
+        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'AAAA', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'AACC', '+', 'PPPP')]
+
+        forward = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                   ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                   ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                   ('@s4/1 abd/1', 'TTT', '+', 'PPP')]
+
+        reverse = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                   ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                   ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                   ('@s4/1 abd/1', 'TTT', '+', 'PPP')]
+
+        bsi = BarcodePairedSequenceFastqIterator(barcodes, forward, reverse)
+        with self.assertRaises(ValueError):
+            list(bsi)
+
+    def test_mismatch_description_override(self):
+        barcodes = [('@s1/2 abc/2', 'AAAA', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'AAAA', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'AACC', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'AACC', '+', 'PPPP')]
+
+        forward = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                   ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                   ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                   ('@s4/1 abd/1', 'TTT', '+', 'PPP')]
+
+        reverse = [('@s1/1 abc/1', 'GGG', '+', 'YYY'),
+                   ('@s2/1 abc/1', 'CCC', '+', 'PPP'),
+                   ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
+                   ('@s4/1 abd/1', 'TTT', '+', 'PPP')]
+
+        bsi = BarcodePairedSequenceFastqIterator(barcodes, forward, reverse,
+                                                 ignore_description_mismatch=True)  # noqa
+        self.assertEqual(len(list(bsi)), 4)
 
     def test_rev_comp_barcodes(self):
         barcodes = [('@s1/2 abc/2', 'TTTT', '+', 'YYYY'),


### PR DESCRIPTION
This pull request exposes an option to allow for ignoring sequence record description mismatches. It came about from applying q2-demux to all of the sequencing runs from the AGP, and observing that at least one sequencing run had mismatches in the description fields but the IDs otherwise matched.

One note, the `seqs` iterator is implicitly constructed so I could not see a way to easily pass in a parameter. Instead, the flag on the instance is toggled within the API methods.

Separately, the `BarcodePairedSequenceFastqIterator` object did not have tests for description mismatch so those were added.