### PR TITLE
Reorder barcode trimming to occur prior to reverse complement

### DIFF
--- a/q2_demux/_demux.py
+++ b/q2_demux/_demux.py
@@ -296,10 +296,10 @@ def emp_single(seqs: BarcodeSequenceFastqIterator,
     ec_details = ECDetails(ec_details_fmt)
 
     for i, (barcode_record, sequence_record) in enumerate(seqs, start=1):
-        barcode_read = barcode_record[1]
+        raw_barcode_read = barcode_record[1][:barcode_len]
         if rev_comp_barcodes:
-            barcode_read = str(skbio.DNA(barcode_read).reverse_complement())
-        raw_barcode_read = barcode_read[:barcode_len]
+            barcode_as_DNA = skbio.DNA(raw_barcode_read)
+            raw_barcode_read = str(barcode_as_DNA.reverse_complement())
 
         if golay_error_correction:
             # A three bit filter is implicitly used by the decoder. See Hamady
@@ -398,10 +398,10 @@ def emp_paired(seqs: BarcodePairedSequenceFastqIterator,
 
     for i, record in enumerate(seqs, start=1):
         barcode_record, forward_record, reverse_record = record
-        barcode_read = barcode_record[1]
+        raw_barcode_read = barcode_record[1][:barcode_len]
         if rev_comp_barcodes:
-            barcode_read = str(skbio.DNA(barcode_read).reverse_complement())
-        raw_barcode_read = barcode_read[:barcode_len]
+            barcode_as_DNA = skbio.DNA(raw_barcode_read)
+            raw_barcode_read = str(barcode_as_DNA.reverse_complement())
 
         if golay_error_correction:
             # A three bit filter is implicitly used by the decoder. See Hamady

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -529,9 +529,9 @@ class EmpSingleTests(unittest.TestCase, EmpTestingUtils):
         # NOTE: these barcodes are the
         barcodes = [('@s1/2 abc/2', 'TTTTG', '+', 'YYYY'),
                     ('@s2/2 abc/2', 'TTAAG', '+', 'PPPP'),
-                    ('@s3/2 abc/2', 'TTGGC', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'GGTTC', '+', 'PPPP'),
                     ('@s4/2 abc/2', 'TTAAC', '+', 'PPPP'),
-                    ('@s5/2 abc/2', 'TTGGT', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'GGTTT', '+', 'PPPP'),
                     ('@s6/2 abc/2', 'TTTTC', '+', 'PPPP'),
                     ('@s7/2 abc/2', 'GCCGT', '+', 'PPPP'),
                     ('@s8/2 abc/2', 'TTCCT', '+', 'PPPP'),

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -526,17 +526,17 @@ class EmpSingleTests(unittest.TestCase, EmpTestingUtils):
         self._barcode_trimming(barcodes, False)
 
     def test_barcode_trimming_rev_comp_barcodes(self):
-        # NOTE: these barcodes are the
+        # NOTE: the 5th nucleotide in these barcodes should be trimmed off
         barcodes = [('@s1/2 abc/2', 'TTTTG', '+', 'YYYY'),
                     ('@s2/2 abc/2', 'TTAAG', '+', 'PPPP'),
-                    ('@s3/2 abc/2', 'GGTTC', '+', 'PPPP'),
-                    ('@s4/2 abc/2', 'TTAAC', '+', 'PPPP'),
-                    ('@s5/2 abc/2', 'GGTTT', '+', 'PPPP'),
-                    ('@s6/2 abc/2', 'TTTTC', '+', 'PPPP'),
-                    ('@s7/2 abc/2', 'GCCGT', '+', 'PPPP'),
-                    ('@s8/2 abc/2', 'TTCCT', '+', 'PPPP'),
-                    ('@s9/2 abc/2', 'GCCGT', '+', 'PPPP'),
-                    ('@s10/2 abc/2', 'GCCGT', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'GGTTG', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'GGTTG', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'TTTTN', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'GCCGG', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'TTCCG', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'GCCGG', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'GCCGG', '+', 'PPPP'),
                     ('@s11/2 abc/2', 'TTCCG', '+', 'PPPP')]
         self._barcode_trimming(barcodes, True)
 

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -523,8 +523,27 @@ class EmpSingleTests(unittest.TestCase, EmpTestingUtils):
                     ('@s9/2 abc/2', 'CGGCG', '+', 'PPPP'),
                     ('@s10/2 abc/2', 'CGGCG', '+', 'PPPP'),
                     ('@s11/2 abc/2', 'GGAAG', '+', 'PPPP')]
+        self._barcode_trimming(barcodes, False)
+
+    def test_barcode_trimming_rev_comp_barcodes(self):
+        # NOTE: these barcodes are the
+        barcodes = [('@s1/2 abc/2', 'TTTTG', '+', 'YYYY'),
+                    ('@s2/2 abc/2', 'TTAAG', '+', 'PPPP'),
+                    ('@s3/2 abc/2', 'TTGGC', '+', 'PPPP'),
+                    ('@s4/2 abc/2', 'TTAAC', '+', 'PPPP'),
+                    ('@s5/2 abc/2', 'TTGGT', '+', 'PPPP'),
+                    ('@s6/2 abc/2', 'TTTTC', '+', 'PPPP'),
+                    ('@s7/2 abc/2', 'GCCGT', '+', 'PPPP'),
+                    ('@s8/2 abc/2', 'TTCCT', '+', 'PPPP'),
+                    ('@s9/2 abc/2', 'GCCGT', '+', 'PPPP'),
+                    ('@s10/2 abc/2', 'GCCGT', '+', 'PPPP'),
+                    ('@s11/2 abc/2', 'TTCCG', '+', 'PPPP')]
+        self._barcode_trimming(barcodes, True)
+
+    def _barcode_trimming(self, barcodes, rev_comp_barcodes):
         bsi = BarcodeSequenceFastqIterator(barcodes, self.sequences)
         actual, ecc = emp_single(bsi, self.barcode_map,
+                                 rev_comp_barcodes=rev_comp_barcodes,
                                  golay_error_correction=False)
         output_fastq = list(actual.sequences.iter_views(FastqGzFormat))
         # five per-sample files were written


### PR DESCRIPTION
I’ve been examining results from q2-demux that disagree with QIIME 1's `split_libraries_fastq.py` when the machine yielded index reads are not the expected length. As an example, “TGTCCAGGTTTAA” was observed in the first round of the AGP, which used the EMP protocol although the index read is 13 nucleotides long. In that sequencing run, most if not all barcodes are 13nt (examined first 125k records). The valid Golay code is the reverse complement of the first 12nt (“TAAACCTGGACA”). 

Prior to the introduction to Golay decoding in q2-demux, barcodes were trimmed to a [specific length](https://github.com/qiime2/q2-demux/commit/f3ad5b217ba6990eb6d8305c029f586078c48c03#diff-ed7c050e3aef63975d8363bc0f55dc9156a86528eb4e55f5b547763d1b4303c9R99 ) where the length is determined based on the barcodes in the sample mapping file.

However, if the index reads are reverse complemented, the trimming occurs after the reverse complement. With this index read, this yields “TTAAACCTGGAC” which isn’t in the list of EMP Golay codes. I first noticed this when comparing per-sample sequence counts from Qiita and when the data were separately processed in q2-demux, and saw a large difference for this sequencing run. 

This pull request adds a test for trimming with reverse complement and moves the trimming logic to occur prior to reverse complement.

The context of this pull request was discussed with @gregcaporaso 