### PR TITLE
BUG: removes NaNs in demux summarize

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
-    - lxml
 
 test:
   requires:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
+    - lxml
 
 test:
   requires:
@@ -49,7 +50,7 @@ test:
     - qiime2.plugins.demux
 
   commands:
-    - py.test --pyargs q2_demux  
+    - py.test --pyargs q2_demux
 
 about:
   home: https://qiime2.org

--- a/q2_demux/_summarize/_visualizer.py
+++ b/q2_demux/_summarize/_visualizer.py
@@ -188,8 +188,7 @@ def summarize(output_dir: str, data: _PlotQualView, n: int = 10000) -> None:
                             result.max(), sequence_count[direction]]],
                           index=['%s reads' % (direction,)],
                           columns=summary_columns)
-        context['result_data'] = pd.concat([context['result_data'], df],
-                                           axis=1)
+        context['result_data'] = pd.concat([context['result_data'], df])
 
         html_df = result.to_frame()
         context['result'] = context['result'].join(html_df, how='outer')

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -1233,6 +1233,16 @@ class SummarizeTests(TestPluginBase):
                           ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
                           ('@s4/1 abc/1', 'TTT', '+', 'PPP')]
 
+    def assert_no_nans_in_tables(self, fh):
+        '''
+        Checks for NaNs present in any of the tables in the indicated file then
+        resets to the head of the file
+        '''
+        tables = pd.read_html(fh)
+        for df in tables:
+            self.assertFalse(df.isnull().values.any())
+        fh.seek(0)
+
     def test_basic(self):
         bsi = BarcodeSequenceFastqIterator(self.barcodes, self.sequences)
 
@@ -1269,13 +1279,7 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
-                # Checks for NaNs present in any of the tables in the
-                # overview.html
-                tables = pd.read_html(fh)
-                for df in tables:
-                    self.assertFalse(df.isnull().values.any())
-
-                fh.seek(0)
+                self.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)
@@ -1312,6 +1316,7 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
+                self.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>1</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -1269,6 +1269,13 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
+                # Checks for NaNs present in any of the tables in the
+                # overview.html
+                tables = pd.read_html(fh)
+                for df in tables:
+                    self.assertFalse(df.isnull().values.any())
+
+                fh.seek(0)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -1269,7 +1269,7 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
-                qiime2.sdk.util.assert_no_nans_in_tables(fh)
+                qiime2.plugin.testing.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)
@@ -1306,7 +1306,7 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
-                qiime2.sdk.util.assert_no_nans_in_tables(fh)
+                qiime2.plugin.testing.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>1</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -19,7 +19,7 @@ import skbio
 import qiime2
 import numpy.testing as npt
 
-from qiime2.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase, assert_no_nans_in_tables
 from q2_demux._demux import (BarcodeSequenceFastqIterator,
                              BarcodePairedSequenceFastqIterator)
 from q2_demux import (emp_single, emp_paired, partition_samples_single,
@@ -1269,7 +1269,7 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
-                qiime2.plugin.testing.assert_no_nans_in_tables(fh)
+                assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)
@@ -1306,7 +1306,7 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
-                qiime2.plugin.testing.assert_no_nans_in_tables(fh)
+                assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>1</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -20,7 +20,6 @@ import qiime2
 import numpy.testing as npt
 
 from qiime2.plugin.testing import TestPluginBase
-from qiime2.core.testing.util import assert_no_nans_in_tables
 from q2_demux._demux import (BarcodeSequenceFastqIterator,
                              BarcodePairedSequenceFastqIterator)
 from q2_demux import (emp_single, emp_paired, partition_samples_single,
@@ -1270,7 +1269,7 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
-                assert_no_nans_in_tables(fh)
+                qiime2.sdk.util.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)
@@ -1307,7 +1306,7 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
-                assert_no_nans_in_tables(fh)
+                qiime2.sdk.util.assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>1</td>', html)

--- a/q2_demux/tests/test_demux.py
+++ b/q2_demux/tests/test_demux.py
@@ -20,6 +20,7 @@ import qiime2
 import numpy.testing as npt
 
 from qiime2.plugin.testing import TestPluginBase
+from qiime2.core.testing.util import assert_no_nans_in_tables
 from q2_demux._demux import (BarcodeSequenceFastqIterator,
                              BarcodePairedSequenceFastqIterator)
 from q2_demux import (emp_single, emp_paired, partition_samples_single,
@@ -1233,16 +1234,6 @@ class SummarizeTests(TestPluginBase):
                           ('@s3/1 abc/1', 'AAA', '+', 'PPP'),
                           ('@s4/1 abc/1', 'TTT', '+', 'PPP')]
 
-    def assert_no_nans_in_tables(self, fh):
-        '''
-        Checks for NaNs present in any of the tables in the indicated file then
-        resets to the head of the file
-        '''
-        tables = pd.read_html(fh)
-        for df in tables:
-            self.assertFalse(df.isnull().values.any())
-        fh.seek(0)
-
     def test_basic(self):
         bsi = BarcodeSequenceFastqIterator(self.barcodes, self.sequences)
 
@@ -1279,7 +1270,7 @@ class SummarizeTests(TestPluginBase):
             self.assertTrue(os.path.exists(qual_forward_fp))
             self.assertTrue(os.path.getsize(qual_forward_fp) > 0)
             with open(index_fp, 'r') as fh:
-                self.assert_no_nans_in_tables(fh)
+                assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>3</td>', html)
@@ -1316,7 +1307,7 @@ class SummarizeTests(TestPluginBase):
             png_fp = os.path.join(output_dir, 'demultiplex-summary.png')
             self.assertFalse(os.path.exists(png_fp))
             with open(index_fp, 'r') as fh:
-                self.assert_no_nans_in_tables(fh)
+                assert_no_nans_in_tables(fh)
                 html = fh.read()
                 self.assertIn('<th>Minimum</th>\n      <td>1</td>', html)
                 self.assertIn('<th>Maximum</th>\n      <td>1</td>', html)


### PR DESCRIPTION
Use the default axis=0 (index) for pd.concat to get rid of the NaNs in `demux_summarize`
