### PR TITLE
CI: adds lxml as a test req

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -43,6 +43,9 @@ test:
     - q2templates >={{ q2templates }}
     - q2-types >={{ q2_types }}
     - pytest
+    # lxml is needed due to this framework change that's used in demux tests:
+    # https://github.com/qiime2/qiime2/pull/735
+    - lxml
 
   imports:
     - q2_demux


### PR DESCRIPTION
lxml is being added as a test dependency because [assert_no_nans_in_tables](https://github.com/qiime2/qiime2/pull/735) is imported from the framework and used in `test_basic` and `test_sample_single`. This failed [Prepare PR](https://github.com/qiime2/distributions/actions/runs/7226268217/job/19695770839?pr=55#step:8:331) is where this was discovered.