### PR TITLE
DEP: removes lxml from test deps

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -43,9 +43,6 @@ test:
     - q2templates >={{ q2templates }}
     - q2-types >={{ q2_types }}
     - pytest
-    # lxml is needed due to this framework change that's used in demux tests:
-    # https://github.com/qiime2/qiime2/pull/735
-    - lxml
 
   imports:
     - q2_demux


### PR DESCRIPTION
removing lxml from test deps because it will be added to the framework's run reqs (instead of test reqs). this is needed b/c of [this helper](https://github.com/qiime2/qiime2/pull/735) in the framework.