### PR TITLE
ENH: Adds SampleData[JoinedSequencesWithQuality] as input for partition_samples_single

### DIFF
--- a/q2_demux/plugin_setup.py
+++ b/q2_demux/plugin_setup.py
@@ -138,12 +138,13 @@ num_partitions_description = 'The number of partitions to split the' \
                              ' partitioning into individual samples.'
 partitioned_demux_description = 'The partitioned demultiplexed sequences.'
 
+T = TypeMatch([SequencesWithQuality, JoinedSequencesWithQuality])
 plugin.methods.register_function(
     function=q2_demux.partition_samples_single,
-    inputs={'demux': SampleData[SequencesWithQuality]},
+    inputs={'demux': SampleData[T]},
     parameters={'num_partitions': Int % Range(1, None)},
     outputs=[
-        ('partitioned_demux', Collection[SampleData[SequencesWithQuality]]),
+        ('partitioned_demux', Collection[SampleData[T]]),
     ],
     input_descriptions={
         'demux': demux_description


### PR DESCRIPTION
In order to make SampleData[JoinedSequencesWithQuality] a valid input for `moshpit classify-kraken2`(https://github.com/bokulich-lab/q2-moshpit/pull/202), We need to be able to partition SampleData[JoinedSequencesWithQuality]. 