### PR TITLE
MAINT: remove `node_modules` from conda pkg build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ include = ["q2_demux*"]
 
 [tool.setuptools.package-data]
 q2_demux = ["**/*"]
+
+[tool.setuptools.exclude-package-data]
+q2_demux = ["**/node_modules/**"]


### PR DESCRIPTION
PR xref that prompted this change: https://github.com/qiime2/q2-composition/pull/150