### PR TITLE
ENH: add ValueError to filter-samples if no samples remain after filtering.

### DIFF
--- a/q2_demux/_filter.py
+++ b/q2_demux/_filter.py
@@ -47,6 +47,9 @@ def filter_samples(demux: _PlotQualView, metadata: Metadata = None,
         ids_empty = _get_empty_sample_ids(manifest)
         ids_to_keep = set(ids_to_keep) - set(ids_empty)
 
+    if len(ids_to_keep) == 0:
+        raise ValueError("No samples remain after filtering.")
+
     try:
         for id in ids_to_keep:
             forward = manifest.loc[id].forward

--- a/q2_demux/tests/test_filter.py
+++ b/q2_demux/tests/test_filter.py
@@ -309,6 +309,5 @@ class FilterSamplesTests(TestPluginBase):
                 filter_samples(demux, metadata, where, True, remove_empty)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/q2_demux/tests/test_filter.py
+++ b/q2_demux/tests/test_filter.py
@@ -298,8 +298,8 @@ class FilterSamplesTests(TestPluginBase):
             (self.sample_single, self.md_single_subset, None, True),
             (self.sample_single, self.md_single_subset, "Study='A'", True),
             (self.sample_single, self.md_single_subset, "Study='A' OR Study='B'", True),
-
         ]
+        
         for (demux, metadata, where, remove_empty) in args:
             with self.assertRaisesRegex(ValueError, "No samples remain"):
                 filter_samples(demux, metadata, where, True, remove_empty)

--- a/q2_demux/tests/test_filter.py
+++ b/q2_demux/tests/test_filter.py
@@ -289,21 +289,25 @@ class FilterSamplesTests(TestPluginBase):
     def test_filter_value_error_no_samples_remain(self):
         args = [
             (self.sample_paired, self.md_paired_all, None, False),
-            (self.sample_paired, self.md_paired_all, "Study='A' OR Study='B'", False),
+            (self.sample_paired, self.md_paired_all,
+             "Study='A' OR Study='B'", False),
             (self.sample_paired, self.md_paired_subset, None, True),
             (self.sample_paired, self.md_paired_subset, "Study='A'", True),
-            (self.sample_paired, self.md_paired_subset, "Study='A' OR Study='B'", True),
+            (self.sample_paired, self.md_paired_subset,
+             "Study='A' OR Study='B'", True),
             (self.sample_single, self.md_single_all, None, False),
-            (self.sample_single, self.md_single_all, "Study='A' OR Study='B'", False),
+            (self.sample_single, self.md_single_all,
+             "Study='A' OR Study='B'", False),
             (self.sample_single, self.md_single_subset, None, True),
             (self.sample_single, self.md_single_subset, "Study='A'", True),
-            (self.sample_single, self.md_single_subset, "Study='A' OR Study='B'", True),
+            (self.sample_single, self.md_single_subset,
+             "Study='A' OR Study='B'", True),
         ]
-        
+
         for (demux, metadata, where, remove_empty) in args:
             with self.assertRaisesRegex(ValueError, "No samples remain"):
                 filter_samples(demux, metadata, where, True, remove_empty)
-    
+
 
 
 if __name__ == '__main__':

--- a/q2_demux/tests/test_filter.py
+++ b/q2_demux/tests/test_filter.py
@@ -73,10 +73,8 @@ class FilterSamplesTests(TestPluginBase):
             self._assert_single_contains(dir_fmt, exp)
 
     def test_filter_single_all_exclude(self):
-        exps = [(None, []),
-                ("Study='A'", ['sample2']),
-                ("Study='B'", ['sample1']),
-                ("Study='A' OR Study='B'", [])]
+        exps = [("Study='A'", ['sample2']),
+                ("Study='B'", ['sample1'])]
         for (where, exp) in exps:
             dir_fmt = filter_samples(self.sample_single, self.md_single_all,
                                      where, True)
@@ -157,10 +155,8 @@ class FilterSamplesTests(TestPluginBase):
             self._assert_paired_contains(dir_fmt, exp)
 
     def test_filter_paired_all_exclude(self):
-        exps = [(None, []),
-                ("Study='A'", ['sample2R1', 'sample2R2']),
-                ("Study='B'", ['sample1R1', 'sample1R2']),
-                ("Study='A' OR Study='B'", [])]
+        exps = [("Study='A'", ['sample2R1', 'sample2R2']),
+                ("Study='B'", ['sample1R1', 'sample1R2'])]
         for (where, exp) in exps:
             dir_fmt = filter_samples(self.sample_paired, self.md_paired_all,
                                      where, True)
@@ -271,38 +267,43 @@ class FilterSamplesTests(TestPluginBase):
         self._assert_single_contains(dir_fmt, ['sample1'])
 
     def test_filter_single_subset_exclude_empty(self):
-        exps = [
-            (None, True, []),
-            ("Study='A'", True, []),
-            ("Study='A' OR Study='B'", True, []),
-            ("Study='A'", False, ['sample1']),
-        ]
-        for (where, exclude, exp) in exps:
-            dir_fmt = filter_samples(
-                demux=self.sample_single,
-                metadata=self.md_single_subset,
-                where=where,
-                exclude_ids=exclude,
-                remove_empty=True,
-            )
-            self._assert_single_contains(dir_fmt, exp)
+        dir_fmt = filter_samples(
+            demux=self.sample_single,
+            metadata=self.md_single_subset,
+            where="Study='A'",
+            exclude_ids=False,
+            remove_empty=True,
+        )
+        self._assert_single_contains(dir_fmt, ['sample1'])
 
     def test_filter_paired_subset_exclude_empty(self):
-        exps = [
-            (None, True, []),
-            ("Study='A'", True, []),
-            ("Study='A' OR Study='B'", True, []),
-            ("Study='A'", False, ['sample1R1', 'sample1R2']),
+        dir_fmt = filter_samples(
+            demux=self.sample_paired,
+            metadata=self.md_paired_subset,
+            where="Study='A'",
+            exclude_ids=False,
+            remove_empty=True,
+        )
+        self._assert_paired_contains(dir_fmt, ['sample1R1', 'sample1R2'])
+
+    def test_filter_value_error_no_samples_remain(self):
+        args = [
+            (self.sample_paired, self.md_paired_all, None, False),
+            (self.sample_paired, self.md_paired_all, "Study='A' OR Study='B'", False),
+            (self.sample_paired, self.md_paired_subset, None, True),
+            (self.sample_paired, self.md_paired_subset, "Study='A'", True),
+            (self.sample_paired, self.md_paired_subset, "Study='A' OR Study='B'", True),
+            (self.sample_single, self.md_single_all, None, False),
+            (self.sample_single, self.md_single_all, "Study='A' OR Study='B'", False),
+            (self.sample_single, self.md_single_subset, None, True),
+            (self.sample_single, self.md_single_subset, "Study='A'", True),
+            (self.sample_single, self.md_single_subset, "Study='A' OR Study='B'", True),
+
         ]
-        for (where, exclude, exp) in exps:
-            dir_fmt = filter_samples(
-                demux=self.sample_paired,
-                metadata=self.md_paired_subset,
-                where=where,
-                exclude_ids=exclude,
-                remove_empty=True,
-            )
-            self._assert_paired_contains(dir_fmt, exp)
+        for (demux, metadata, where, remove_empty) in args:
+            with self.assertRaisesRegex(ValueError, "No samples remain"):
+                filter_samples(demux, metadata, where, True, remove_empty)
+    
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #180 

Adds a check in filter-samples if samples remain after filtering if not it raises a ValueError with a message. 
